### PR TITLE
fix[#66]: Improve JMS connection factory instantiation

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -48,6 +48,8 @@
     <swagger.parser.version>1.0.34</swagger.parser.version>
     <assertj-core.version>3.14.0</assertj-core.version>
     <s3-storage-wagon.version>2.3</s3-storage-wagon.version>
+    <activemq.version>5.15.11</activemq.version>
+    <mockito.version>3.3.3</mockito.version>
 
     <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
     <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
@@ -101,6 +103,16 @@
         <artifactId>citrus-camel</artifactId>
         <version>${citrus.version}</version>
       </dependency>
+      <dependency>
+        <groupId>com.consol.citrus</groupId>
+        <artifactId>citrus-jms</artifactId>
+        <version>${citrus.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.consol.citrus</groupId>
+        <artifactId>citrus-kafka</artifactId>
+        <version>${citrus.version}</version>
+      </dependency>
 
       <!-- Cucumber -->
       <dependency>
@@ -132,6 +144,11 @@
         <groupId>org.assertj</groupId>
         <artifactId>assertj-core</artifactId>
         <version>${assertj-core.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-core</artifactId>
+        <version>${mockito.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/java/steps/yaks-jms/pom.xml
+++ b/java/steps/yaks-jms/pom.xml
@@ -28,10 +28,6 @@
   <artifactId>yaks-jms</artifactId>
   <name>YAKS :: Steps :: JMS</name>
 
-  <properties>
-    <activemq.version>5.15.11</activemq.version>
-  </properties>
-
   <build>
     <plugins>
       <plugin>
@@ -73,23 +69,18 @@
 
     <dependency>
       <groupId>com.consol.citrus</groupId>
-      <artifactId>citrus-java-dsl</artifactId>
-      <version>${citrus.version}</version>
-    </dependency>
-   
-    <dependency>
-      <groupId>com.consol.citrus</groupId>
       <artifactId>citrus-jms</artifactId>
-      <version>${citrus.version}</version>
     </dependency>
-    <!-- Test scope -->
+
+    <!-- Provided scope dependencies -->
     <dependency>
       <groupId>org.apache.activemq</groupId>
       <artifactId>activemq-client</artifactId>
       <version>${activemq.version}</version>
-      <scope>test</scope>
+      <scope>provided</scope>
     </dependency>
 
+    <!-- Test scoped dependencies -->
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
@@ -108,6 +99,16 @@
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j-impl</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/java/steps/yaks-jms/src/main/java/org/citrusframework/yaks/jms/connection/ConnectionFactoryCreator.java
+++ b/java/steps/yaks-jms/src/main/java/org/citrusframework/yaks/jms/connection/ConnectionFactoryCreator.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.yaks.jms.connection;
+
+import javax.jms.ConnectionFactory;
+import java.util.Map;
+import java.util.ServiceLoader;
+
+import org.springframework.util.Assert;
+
+/**
+ * @author Christoph Deppisch
+ */
+public interface ConnectionFactoryCreator {
+
+    ServiceLoader<ConnectionFactoryCreator> SERVICE_LOADER = ServiceLoader.load(ConnectionFactoryCreator.class);
+
+    /**
+     * Create connection factory from given properties.
+     * @param properties
+     * @return
+     */
+    ConnectionFactory create(Map<String, String> properties);
+
+    /**
+     * Creates class from given type information and checks
+     * @param type
+     * @return
+     */
+    boolean supports(Class<?> type);
+
+    /**
+     * Static lookup method makes use of service loader to find a proper connection factory creator implementation for the given type.
+     * @param type
+     * @return
+     * @throws ClassNotFoundException
+     */
+    static ConnectionFactoryCreator lookup(String type) throws ClassNotFoundException {
+        Assert.notNull(type, "Missing connection factory type information");
+        Class<?> connectionFactoryType = Class.forName(type);
+
+        for (ConnectionFactoryCreator connectionFactoryCreator : SERVICE_LOADER) {
+            if (connectionFactoryCreator.supports(connectionFactoryType)) {
+                return connectionFactoryCreator;
+            }
+        }
+
+        return new DefaultConnectionFactoryCreator();
+    }
+}

--- a/java/steps/yaks-jms/src/main/java/org/citrusframework/yaks/jms/connection/DefaultConnectionFactoryCreator.java
+++ b/java/steps/yaks-jms/src/main/java/org/citrusframework/yaks/jms/connection/DefaultConnectionFactoryCreator.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.yaks.jms.connection;
+
+import javax.jms.ConnectionFactory;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Map;
+
+import com.consol.citrus.exceptions.CitrusRuntimeException;
+import org.springframework.util.Assert;
+
+/**
+ * Default connection factory creator implementation. Searches for proper constructor on given type and instantiates
+ * the connection factory. The constructor arguments must be provided as properties in correct order.
+ * @author Christoph Deppisch
+ */
+public class DefaultConnectionFactoryCreator implements ConnectionFactoryCreator {
+
+    @Override
+    public ConnectionFactory create(Map<String, String> properties) {
+        String className = properties.remove("type");
+        Assert.notNull(className, "Missing connection factory type information");
+
+        try {
+            Class<?> type = Class.forName(className);
+
+            if (!(ConnectionFactory.class.isAssignableFrom(type))) {
+                throw new IllegalStateException(String.format("Unsupported type information %s - must be of type %s", type.getName(), ConnectionFactory.class.getName()));
+            }
+
+            Collection<String> constructorArgs = properties.values();
+            Constructor<? extends ConnectionFactory> constructor = Arrays.stream(type.getConstructors())
+                    .filter(c -> c.getParameterCount() == constructorArgs.size()
+                            && Arrays.stream(c.getParameterTypes()).allMatch(paramType -> paramType.equals(String.class)))
+                    .map(c -> (Constructor<? extends ConnectionFactory>) c)
+                    .findFirst()
+                    .orElseThrow(() -> new IllegalStateException("Unable to find matching constructor on connection factory"));
+
+            return constructor.newInstance(constructorArgs.toArray(new Object[0]));
+        } catch (InstantiationException | InvocationTargetException | IllegalAccessException | ClassNotFoundException e) {
+            throw new CitrusRuntimeException(e);
+        }
+    }
+
+    @Override
+    public boolean supports(Class<?> type) {
+        return ConnectionFactory.class.isAssignableFrom(type);
+    }
+}

--- a/java/steps/yaks-jms/src/main/java/org/citrusframework/yaks/jms/connection/activemq/ActiveMQConnectionFactoryCreator.java
+++ b/java/steps/yaks-jms/src/main/java/org/citrusframework/yaks/jms/connection/activemq/ActiveMQConnectionFactoryCreator.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.yaks.jms.connection.activemq;
+
+import javax.jms.ConnectionFactory;
+import java.util.Map;
+
+import org.apache.activemq.ActiveMQConnectionFactory;
+import org.citrusframework.yaks.jms.connection.ConnectionFactoryCreator;
+
+/**
+ * @author Christoph Deppisch
+ */
+public class ActiveMQConnectionFactoryCreator implements ConnectionFactoryCreator {
+
+    @Override
+    public ConnectionFactory create(Map<String, String> properties) {
+        ActiveMQConnectionFactory connectionFactory = new ActiveMQConnectionFactory();
+
+        if (properties.containsKey("brokerUrl")) {
+            connectionFactory.setBrokerURL(properties.get("brokerUrl"));
+        }
+
+        if (properties.containsKey("username")) {
+            connectionFactory.setUserName(properties.get("username"));
+        }
+
+        if (properties.containsKey("password")) {
+            connectionFactory.setPassword(properties.get("password"));
+        }
+
+        return connectionFactory;
+    }
+
+    @Override
+    public boolean supports(Class<?> type) {
+        return ActiveMQConnectionFactory.class.equals(type);
+    }
+}

--- a/java/steps/yaks-jms/src/main/resources/META-INF/services/org.citrusframework.yaks.jms.connection.ConnectionFactoryCreator
+++ b/java/steps/yaks-jms/src/main/resources/META-INF/services/org.citrusframework.yaks.jms.connection.ConnectionFactoryCreator
@@ -1,0 +1,1 @@
+org.citrusframework.yaks.jms.connection.activemq.ActiveMQConnectionFactoryCreator

--- a/java/steps/yaks-jms/src/test/java/org/citrusframework/yaks/jms/connection/ConnectionFactoryCreatorTest.java
+++ b/java/steps/yaks-jms/src/test/java/org/citrusframework/yaks/jms/connection/ConnectionFactoryCreatorTest.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.yaks.jms.connection;
+
+import javax.jms.Connection;
+import javax.jms.ConnectionFactory;
+import javax.jms.JMSContext;
+import javax.jms.JMSException;
+
+import org.apache.activemq.ActiveMQConnectionFactory;
+import org.assertj.core.api.Assertions;
+import org.citrusframework.yaks.jms.connection.activemq.ActiveMQConnectionFactoryCreator;
+import org.junit.Test;
+
+/**
+ * @author Christoph Deppisch
+ */
+public class ConnectionFactoryCreatorTest {
+
+    @Test
+    public void shouldLookup() throws ClassNotFoundException {
+        ConnectionFactoryCreator creator = ConnectionFactoryCreator.lookup(ActiveMQConnectionFactory.class.getName());
+        Assertions.assertThat(ActiveMQConnectionFactoryCreator.class).isEqualTo(creator.getClass());
+    }
+
+    @Test
+    public void shouldLookupDefault() throws ClassNotFoundException {
+        ConnectionFactoryCreator creator = ConnectionFactoryCreator.lookup(DummyConnectionFactory.class.getName());
+        Assertions.assertThat(DefaultConnectionFactoryCreator.class).isEqualTo(creator.getClass());
+    }
+
+    @Test(expected = ClassNotFoundException.class)
+    public void shouldHandleUnsupportedTypeInformation() throws ClassNotFoundException {
+        ConnectionFactoryCreator.lookup("org.unknown.Type");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldHandleMissingTypeInformation() throws ClassNotFoundException {
+        ConnectionFactoryCreator.lookup(null);
+    }
+
+    /**
+     * Empty connection factory implementation for testing.
+     */
+    private static class DummyConnectionFactory implements ConnectionFactory {
+        @Override
+        public Connection createConnection() throws JMSException {
+            return null;
+        }
+
+        @Override
+        public Connection createConnection(String s, String s1) throws JMSException {
+            return null;
+        }
+
+        @Override
+        public JMSContext createContext() {
+            return null;
+        }
+
+        @Override
+        public JMSContext createContext(String s, String s1) {
+            return null;
+        }
+
+        @Override
+        public JMSContext createContext(String s, String s1, int i) {
+            return null;
+        }
+
+        @Override
+        public JMSContext createContext(int i) {
+            return null;
+        }
+    }
+}

--- a/java/steps/yaks-jms/src/test/java/org/citrusframework/yaks/jms/connection/DefaultConnectionFactoryCreatorTest.java
+++ b/java/steps/yaks-jms/src/test/java/org/citrusframework/yaks/jms/connection/DefaultConnectionFactoryCreatorTest.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.yaks.jms.connection;
+
+import javax.jms.ConnectionFactory;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import com.consol.citrus.exceptions.CitrusRuntimeException;
+import org.apache.activemq.ActiveMQConnectionFactory;
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+
+/**
+ * @author Christoph Deppisch
+ */
+public class DefaultConnectionFactoryCreatorTest {
+
+    private DefaultConnectionFactoryCreator connectionFactoryCreator = new DefaultConnectionFactoryCreator();
+
+    @Test
+    public void shouldCreate() {
+        Map<String, String> connectionSettings = new HashMap<>();
+        connectionSettings.put("type", ActiveMQConnectionFactory.class.getName());
+        ConnectionFactory connectionFactory = connectionFactoryCreator.create(connectionSettings);
+
+        Assertions.assertThat(ActiveMQConnectionFactory.class).isEqualTo(connectionFactory.getClass());
+        Assertions.assertThat(ActiveMQConnectionFactory.DEFAULT_BROKER_URL).isEqualTo(((ActiveMQConnectionFactory)connectionFactory).getBrokerURL());
+    }
+
+    @Test
+    public void shouldCreateWithConstructorArgs() {
+        Map<String, String> connectionSettings = new LinkedHashMap<>();
+        connectionSettings.put("type", ActiveMQConnectionFactory.class.getName());
+        connectionSettings.put("username", "foo");
+        connectionSettings.put("password", "secret");
+        connectionSettings.put("brokerUrl", "typ://localhost:61617");
+        ConnectionFactory connectionFactory = connectionFactoryCreator.create(connectionSettings);
+
+        Assertions.assertThat(ActiveMQConnectionFactory.class).isEqualTo(connectionFactory.getClass());
+        Assertions.assertThat("typ://localhost:61617").isEqualTo(((ActiveMQConnectionFactory)connectionFactory).getBrokerURL());
+        Assertions.assertThat("foo").isEqualTo(((ActiveMQConnectionFactory)connectionFactory).getUserName());
+        Assertions.assertThat("secret").isEqualTo(((ActiveMQConnectionFactory)connectionFactory).getPassword());
+    }
+
+    @Test(expected = CitrusRuntimeException.class)
+    public void shouldHandleUnsupportedTypeInformation() {
+        Map<String, String> connectionSettings = new LinkedHashMap<>();
+        connectionSettings.put("type", "org.unknown.Type");
+        connectionFactoryCreator.create(connectionSettings);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldHandleMissingTypeInformation() {
+        connectionFactoryCreator.create(Collections.emptyMap());
+    }
+
+    @Test
+    public void shouldSupports() {
+        Assertions.assertThat(connectionFactoryCreator.supports(ConnectionFactory.class)).isTrue();
+        Assertions.assertThat(connectionFactoryCreator.supports(ActiveMQConnectionFactory.class)).isTrue();
+        Assertions.assertThat(connectionFactoryCreator.supports(String.class)).isFalse();
+    }
+}

--- a/java/steps/yaks-jms/src/test/java/org/citrusframework/yaks/jms/connection/activemq/ActiveMQConnectionFactoryCreatorTest.java
+++ b/java/steps/yaks-jms/src/test/java/org/citrusframework/yaks/jms/connection/activemq/ActiveMQConnectionFactoryCreatorTest.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.yaks.jms.connection.activemq;
+
+import javax.jms.ConnectionFactory;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.apache.activemq.ActiveMQConnectionFactory;
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+
+/**
+ * @author Christoph Deppisch
+ */
+public class ActiveMQConnectionFactoryCreatorTest {
+
+    private ActiveMQConnectionFactoryCreator connectionFactoryCreator = new ActiveMQConnectionFactoryCreator();
+
+    @Test
+    public void shouldCreate() {
+        ConnectionFactory connectionFactory = connectionFactoryCreator.create(Collections.emptyMap());
+
+        Assertions.assertThat(ActiveMQConnectionFactory.class).isEqualTo(connectionFactory.getClass());
+        Assertions.assertThat(ActiveMQConnectionFactory.DEFAULT_BROKER_URL).isEqualTo(((ActiveMQConnectionFactory)connectionFactory).getBrokerURL());
+    }
+
+    @Test
+    public void shouldCreateWithProperties() {
+        Map<String, String> connectionSettings = new LinkedHashMap<>();
+        connectionSettings.put("brokerUrl", "typ://localhost:61617");
+        connectionSettings.put("username", "foo");
+        connectionSettings.put("password", "secret");
+        ConnectionFactory connectionFactory = connectionFactoryCreator.create(connectionSettings);
+
+        Assertions.assertThat(ActiveMQConnectionFactory.class).isEqualTo(connectionFactory.getClass());
+        Assertions.assertThat("typ://localhost:61617").isEqualTo(((ActiveMQConnectionFactory)connectionFactory).getBrokerURL());
+        Assertions.assertThat("foo").isEqualTo(((ActiveMQConnectionFactory)connectionFactory).getUserName());
+        Assertions.assertThat("secret").isEqualTo(((ActiveMQConnectionFactory)connectionFactory).getPassword());
+    }
+
+    @Test
+    public void shouldSupport() {
+        Assertions.assertThat(connectionFactoryCreator.supports(ActiveMQConnectionFactory.class)).isTrue();
+        Assertions.assertThat(connectionFactoryCreator.supports(ConnectionFactory.class)).isFalse();
+    }
+}

--- a/java/steps/yaks-jms/src/test/resources/org/citrusframework/yaks/jms/jms.feature
+++ b/java/steps/yaks-jms/src/test/resources/org/citrusframework/yaks/jms/jms.feature
@@ -1,12 +1,27 @@
 Feature: JMS steps
 
   Background:
-    Given JMS connection factory org.apache.activemq.ActiveMQConnectionFactory
-        | tcp://localhost:61616 |
-    Given jms destination: test
+    Given JMS connection factory
+      | type       | org.apache.activemq.ActiveMQConnectionFactory |
+      | brokerUrl  | tcp://localhost:61616 |
+    Given JMS destination: test
 
-  Scenario: Send and receive body and headers
+  Scenario: Send and receive body
     Given variable body is "citrus:randomString(10)"
     When send message to JMS broker with body: ${body}
     Then expect message in JMS broker with body: ${body}
+
+  Scenario: Send and receive multiline body
+    When send message to JMS broker with body
+    """
+    {
+      "message": "Hello from YAKS!"
+    }
+    """
+    Then expect message in JMS broker with body
+    """
+    {
+      "message": "Hello from YAKS!"
+    }
+    """
 

--- a/java/steps/yaks-kafka/pom.xml
+++ b/java/steps/yaks-kafka/pom.xml
@@ -41,15 +41,9 @@
 
     <dependency>
       <groupId>com.consol.citrus</groupId>
-      <artifactId>citrus-java-dsl</artifactId>
-      <version>${citrus.version}</version>
-    </dependency>
-   
-    <dependency>
-      <groupId>com.consol.citrus</groupId>
       <artifactId>citrus-kafka</artifactId>
-      <version>${citrus.version}</version>
     </dependency>
+
     <!-- Test scope -->
     <dependency>
       <groupId>junit</groupId>

--- a/java/steps/yaks-kafka/src/test/java/org/citrusframework/yaks/kafka/EmbeddedKafkaConfiguration.java
+++ b/java/steps/yaks-kafka/src/test/java/org/citrusframework/yaks/kafka/EmbeddedKafkaConfiguration.java
@@ -25,14 +25,11 @@ import com.consol.citrus.kafka.embedded.EmbeddedKafkaServerBuilder;
 @Configuration
 public class EmbeddedKafkaConfiguration {
 
-	private static int PORT = 9092;
-	private static String TOPICS = "test";
-
 	@Bean
 	public EmbeddedKafkaServer embeddedKafkaServer() {
 		return new EmbeddedKafkaServerBuilder()
-				.kafkaServerPort(PORT)
-				.topics(TOPICS)
+				.kafkaServerPort(9092)
+				.topics("test")
 				.build();
 	}
 }

--- a/java/steps/yaks-kafka/src/test/resources/org/citrusframework/yaks/kafka/kafka.feature
+++ b/java/steps/yaks-kafka/src/test/resources/org/citrusframework/yaks/kafka/kafka.feature
@@ -3,7 +3,7 @@ Feature: Kafka steps
   Background:
     Given Kafka connection
         | url       | localhost:9092 |
-        | topic     | test|
+        | topic     | test |
 
   Scenario: Send and receive body and headers
     Given variable body is "citrus:randomString(10)"
@@ -13,4 +13,3 @@ Feature: Kafka steps
       | ${key} | ${value} |
     Then expect message in Kafka with body and headers: ${body}
       | ${key} | ${value} |
-


### PR DESCRIPTION
Refactor JMS connection factory creation with dedicated helpers that map user provided connection properties to connection factory constructor arguments or setter methods. At the moment provide ActiveMQ connection factory support. By default try to set the constructor arguments on the connection factory with given order by user.

Also add multiline body steps for JMS and Kafka and fix obsolete citrus-java-dsl dependency in Maven POMs.

Fixes #66