### PR TITLE
fix(#78): Refactor CamelK steps

### DIFF
--- a/java/steps/yaks-camel-k/pom.xml
+++ b/java/steps/yaks-camel-k/pom.xml
@@ -35,6 +35,15 @@
     </dependency>
 
     <dependency>
+      <groupId>com.consol.citrus</groupId>
+      <artifactId>citrus-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.consol.citrus</groupId>
+      <artifactId>citrus-cucumber</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>io.fabric8</groupId>
       <artifactId>kubernetes-client</artifactId>
     </dependency>

--- a/java/steps/yaks-camel-k/src/main/java/org/citrusframework/yaks/camelk/CamelKHelper.java
+++ b/java/steps/yaks-camel-k/src/main/java/org/citrusframework/yaks/camelk/CamelKHelper.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.yaks.camelk;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * @author Christoph Deppisch
+ */
+public final class CamelKHelper {
+
+    /** Logger */
+    private static Logger LOG = LoggerFactory.getLogger(CamelKHelper.class);
+
+    private CamelKHelper() {
+        // prevent instantiation of utility class.
+    }
+
+    /**
+     * Retrieve namespace to connect with based on System environment settings.
+     * @return
+     */
+    public static String namespace() {
+        String defaultNamespace = CamelKSettings.getNamespace();
+        if (defaultNamespace != null) {
+            return defaultNamespace;
+        }
+
+        final File namespace = new File("/var/run/secrets/kubernetes.io/serviceaccount/namespace");
+        if (namespace.exists()){
+            try {
+                return new String(Files.readAllBytes(namespace.toPath()), StandardCharsets.UTF_8);
+            } catch (IOException e) {
+                LOG.warn("Failed to read namespace from file {}", namespace, e);
+            }
+        }
+
+        return null;
+    }
+}

--- a/java/steps/yaks-camel-k/src/main/java/org/citrusframework/yaks/camelk/CamelKSettings.java
+++ b/java/steps/yaks-camel-k/src/main/java/org/citrusframework/yaks/camelk/CamelKSettings.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.yaks.camelk;
+
+/**
+ * @author Christoph Deppisch
+ */
+public final class CamelKSettings {
+
+    private static final String CAMELK_PROPERTY_PREFIX = "yaks.camelk.";
+    private static final String CAMELK_ENV_PREFIX = "YAKS_CAMELK_";
+
+    private static final String MAX_ATTEMPTS_PROPERTY = CAMELK_PROPERTY_PREFIX + "max.attempts";
+    private static final String MAX_ATTEMPTS_ENV = CAMELK_ENV_PREFIX + "MAX_ATTEMPTS";
+    private static final String MAX_ATTEMPTS_DEFAULT = "150";
+
+    private static final String DELAY_BETWEEN_ATTEMPTS_PROPERTY = CAMELK_PROPERTY_PREFIX + "delay.between.attempts";
+    private static final String DELAY_BETWEEN_ATTEMPTS_ENV = CAMELK_ENV_PREFIX + "DELAY_BETWEEN_ATTEMPTS";
+    private static final String DELAY_BETWEEN_ATTEMPTS_DEFAULT = "2000";
+
+    private static final String NAMESPACE_PROPERTY = CAMELK_PROPERTY_PREFIX + "namespace";
+    private static final String NAMESPACE_ENV = CAMELK_ENV_PREFIX + "NAMESPACE";
+
+    private CamelKSettings() {
+        // prevent instantiation of utility class
+    }
+
+    /**
+     * Maximum number of attempts when polling for running state and log messages.
+     * @return
+     */
+    public static int getMaxAttempts() {
+        return Integer.parseInt(System.getProperty(MAX_ATTEMPTS_PROPERTY, System.getenv(MAX_ATTEMPTS_ENV) != null ? System.getenv(MAX_ATTEMPTS_ENV) : MAX_ATTEMPTS_DEFAULT));
+    }
+
+    /**
+     * Delay in milliseconds to wait after polling attempt.
+     * @return
+     */
+    public static long getDelayBetweenAttempts() {
+        return Long.parseLong(System.getProperty(DELAY_BETWEEN_ATTEMPTS_PROPERTY, System.getenv(DELAY_BETWEEN_ATTEMPTS_ENV) != null ? System.getenv(DELAY_BETWEEN_ATTEMPTS_ENV) : DELAY_BETWEEN_ATTEMPTS_DEFAULT));
+    }
+
+    /**
+     * Namespace to work on when performing Kubernetes client operations such as creating Pods.
+     * @return
+     */
+    public static String getNamespace() {
+        return System.getProperty(NAMESPACE_PROPERTY, System.getenv(NAMESPACE_ENV));
+    }
+}

--- a/java/steps/yaks-camel-k/src/main/java/org/citrusframework/yaks/camelk/CamelKSteps.java
+++ b/java/steps/yaks-camel-k/src/main/java/org/citrusframework/yaks/camelk/CamelKSteps.java
@@ -17,205 +17,80 @@
 
 package org.citrusframework.yaks.camelk;
 
-import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
-import java.util.Arrays;
-import java.util.HashMap;
 import java.util.Map;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.consol.citrus.TestCaseRunner;
+import com.consol.citrus.annotations.CitrusResource;
+import com.consol.citrus.exceptions.ActionTimeoutException;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
-import io.fabric8.kubernetes.api.model.DoneablePod;
-import io.fabric8.kubernetes.api.model.Pod;
-import io.fabric8.kubernetes.api.model.PodList;
 import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClient;
-import io.fabric8.kubernetes.client.dsl.PodResource;
-import io.fabric8.kubernetes.client.dsl.base.CustomResourceDefinitionContext;
-import org.citrusframework.yaks.camelk.model.Integration;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+
+import static com.consol.citrus.container.Assert.Builder.assertException;
+import static org.citrusframework.yaks.camelk.actions.CreateIntegrationTestAction.Builder.createIntegration;
+import static org.citrusframework.yaks.camelk.actions.VerifyIntegrationTestAction.Builder.verifyIntegration;
 
 
 public class CamelKSteps {
 
-    private static final int MAX_ATTEMPTS = System.getenv("YAKS_CAMELK_MAX_ATTEMPTS") != null ? Integer.valueOf(System.getenv("YAKS_CAMELK_MAX_ATTEMPTS")) : 150;
-    private static final long DELAY_BETWEEN_ATTEMPTS = System.getenv("YAKS_CAMELK_DELAY_BETWEEN_ATTEMPTS") != null ? Long.valueOf(System.getenv("YAKS_CAMELK_DELAY_BETWEEN_ATTEMPTS")) : 2000;
-
     private KubernetesClient client;
-    private ObjectMapper obj = new ObjectMapper();
 
-	/** Logger */
-    private static final Logger LOG = LoggerFactory.getLogger(CamelKSteps.class);
+    @CitrusResource
+    private TestCaseRunner runner;
 
 	@Given("^new integration with name ([a-z0-9_]+\\.[a-z0-9_]+) with configuration:$")
 	public void createNewIntegration(String name, Map<String, String> configuration) throws IOException {
 		if(configuration.get("source") == null) {
 			throw new IllegalStateException("Specify 'source' parameter");
 		}
-		createIntegration(name, configuration.get("source"), configuration.get("dependencies"), configuration.get("traits"));
 
+		runner.run(createIntegration()
+                    .client(client())
+                    .integrationName(name)
+                    .source(configuration.get("source"))
+                    .dependencies(configuration.get("dependencies"))
+                    .traits(configuration.get("traits")));
 	}
 
 	@Given("^new integration with name ([a-z0-9_]+\\.[a-z0-9_]+)$")
 	public void createNewIntegration(String name, String source) throws IOException {
-		createIntegration(name, source, null, null);
-
+        runner.run(createIntegration()
+                    .client(client())
+                    .integrationName(name)
+                    .source(source));
 	}
 
     @Given("^integration ([a-z0-9-.]+) is running$")
     @Then("^integration ([a-z0-9-.]+) should be running$")
-    public void shouldBeRunning(String integration) throws InterruptedException {
-        if (getRunningIntegrationPod(integration, MAX_ATTEMPTS, DELAY_BETWEEN_ATTEMPTS) == null) {
-            throw new IllegalStateException(String.format("integration %s not running after %d attempts", integration, MAX_ATTEMPTS));
-        }
+    public void shouldBeRunning(String name) throws InterruptedException {
+        runner.run(verifyIntegration()
+                .isRunning(name));
     }
 
     @Then("^integration ([a-z0-9-.]+) should print (.*)$")
-    public void shouldPrint(String integration, String message) throws InterruptedException {
-        Pod pod = getRunningIntegrationPod(integration, MAX_ATTEMPTS, DELAY_BETWEEN_ATTEMPTS);
-        if (pod == null) {
-            throw new IllegalStateException(String.format("integration %s not running after %d attempts", integration, MAX_ATTEMPTS));
-        }
-        if (!isIntegrationPodLogContaining(pod, message, MAX_ATTEMPTS, DELAY_BETWEEN_ATTEMPTS)) {
-            throw new IllegalStateException(String.format("integration %s has not printed message %s after %d attempts", integration, message, MAX_ATTEMPTS));
-        }
+    public void shouldPrint(String name, String message) throws InterruptedException {
+        runner.run(verifyIntegration()
+                .client(client())
+                .isRunning(name)
+                .waitForLogMessage(message));
     }
 
-    private boolean isIntegrationPodLogContaining(Pod pod, String message, int attempts, long delayBetweenAttempts) throws InterruptedException {
-        for (int i = 0; i < attempts; i++) {
-            String log = getIntegrationPodLogs(pod);
-            if (log.contains(message)) {
-                return true;
-            }
-            Thread.sleep(delayBetweenAttempts);
-        }
-        return false;
+    @Then("^integration ([a-z0-9-.]+) should not print (.*)$")
+    public void shouldNotPrint(String name, String message) throws InterruptedException {
+        runner.run(assertException()
+                .exception(ActionTimeoutException.class)
+                .when(verifyIntegration()
+                    .client(client())
+                    .isRunning(name)
+                    .waitForLogMessage(message)));
     }
 
-    private String getIntegrationPodLogs(Pod pod) {
-        PodResource<Pod, DoneablePod> podRes = client.pods()
-                .inNamespace(namespace())
-                .withName(pod.getMetadata().getName());
-
-        String containerName = null;
-        if (pod.getSpec() != null && pod.getSpec().getContainers() != null && pod.getSpec().getContainers().size() > 1) {
-            containerName = pod.getSpec().getContainers().get(0).getName();
-        }
-
-        String logs;
-        if (containerName != null) {
-            logs = podRes.inContainer(containerName).getLog();
-        } else {
-            logs = podRes.getLog();
-        }
-        return logs;
-    }
-
-    private Pod getRunningIntegrationPod(String integration, int attempts, long delayBetweenAttempts) throws InterruptedException {
-        for (int i = 0; i < attempts; i++) {
-            Pod pod = getRunningIntegrationPod(integration);
-            if (pod != null) {
-                return pod;
-            }
-            Thread.sleep(delayBetweenAttempts);
-        }
-        return null;
-    }
-
-    private Pod getRunningIntegrationPod(String integration) {
-        PodList pods = client().pods().inNamespace(namespace()).withLabel("camel.apache.org/integration", integration).list();
-        if (pods.getItems().size() == 0) {
-            return null;
-        }
-        for (Pod p : pods.getItems()) {
-            if (p.getStatus() != null && "Running".equals(p.getStatus().getPhase())) {
-                return p;
-            }
-        }
-        return null;
-    }
-
-	private CustomResourceDefinitionContext getIntegrationCRD() {
-		return new CustomResourceDefinitionContext.Builder()
-				.withName(Integration.CRD_INTEGRATION_NAME)
-				.withGroup(Integration.CRD_GROUP)
-				.withVersion(Integration.CRD_VERSION)
-				.withPlural("integrations")
-				.withScope("Namespaced")
-				.build();
-	}
-
-	private void createIntegration(String name, String source, String dependencies, String traits) {
-		final Integration.Builder integrationBuilder = new Integration.Builder()
-				.name(name)
-				.source(source);
-
-		if(dependencies != null && !dependencies.isEmpty()) {
-			integrationBuilder.dependencies(Arrays.asList(dependencies.split(",")));
-		}
-
-		if (traits != null && !traits.isEmpty()) {
-			final Map<String, Integration.TraitConfig> traitConfigMap = new HashMap<>();
-			for(String t : traits.split(",")){
-				//traitName.key=value
-				if(!validateTraitFormat(t)) {
-					throw new IllegalArgumentException("Trait" + t + "does not match format traitName.key=value");
-				}
-				final String[] trait = t.split("\\.",2);
-				final String[] traitConfig = trait[1].split("=", 2);
-				if(traitConfigMap.containsKey(trait[0])) {
-					traitConfigMap.get(trait[0]).add(traitConfig[0], traitConfig[1]);
-				} else {
-					traitConfigMap.put(trait[0],  new Integration.TraitConfig(traitConfig[0], traitConfig[1]));
-				}
-			}
-			integrationBuilder.traits(traitConfigMap);
-		}
-
-		final Integration i = integrationBuilder.build();
-
-		final CustomResourceDefinitionContext crdContext = getIntegrationCRD();
-
-		try {
-			Map<String, Object> result = client().customResource(crdContext).createOrReplace(namespace(), obj.writeValueAsString(i));
-			if(result.get("message") != null) {
-				throw new IllegalStateException(result.get("message").toString());
-			}
-		} catch (IOException e) {
-			throw new IllegalStateException("Can't create Integration JSON object", e);
-		}
-	}
-
-	private boolean validateTraitFormat(String trait) {
-		String patternString = "[A-Za-z-0-9]+\\.[A-Za-z-0-9]+=[A-Za-z-0-9]+";
-
-		Pattern pattern = Pattern.compile(patternString);
-
-		Matcher matcher = pattern.matcher(trait);
-		return matcher.matches();
-	}
-
-
-
-    private String namespace() {
-        String result = System.getenv("NAMESPACE");
-		final File namespace = new File("/var/run/secrets/kubernetes.io/serviceaccount/namespace");
-		if(result == null && namespace.exists()){
-			try {
-				result = new String(Files.readAllBytes(namespace.toPath()));
-			} catch (IOException e) {
-				LOG.warn("Can't read {}", namespace, e);
-				return null;
-			}
-		}
-		return result;
-    }
-
+    /**
+     * Lazy initialize a default Kubernetes client.
+     * @return
+     */
     private KubernetesClient client() {
         if (this.client == null) {
             this.client = new DefaultKubernetesClient();

--- a/java/steps/yaks-camel-k/src/main/java/org/citrusframework/yaks/camelk/actions/CreateIntegrationTestAction.java
+++ b/java/steps/yaks-camel-k/src/main/java/org/citrusframework/yaks/camelk/actions/CreateIntegrationTestAction.java
@@ -1,0 +1,194 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.yaks.camelk.actions;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import com.consol.citrus.AbstractTestActionBuilder;
+import com.consol.citrus.actions.AbstractTestAction;
+import com.consol.citrus.context.TestContext;
+import com.consol.citrus.exceptions.CitrusRuntimeException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.fabric8.kubernetes.client.DefaultKubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.dsl.base.CustomResourceDefinitionContext;
+import org.citrusframework.yaks.camelk.CamelKHelper;
+import org.citrusframework.yaks.camelk.model.Integration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Test action creates new Camel-K integration with given name and source code. Uses given Kubernetes client to
+ * create a custom resource of type integration.
+ *
+ * @author Christoph Deppisch
+ */
+public class CreateIntegrationTestAction extends AbstractTestAction {
+
+    /** Logger */
+    private static Logger LOG = LoggerFactory.getLogger(CreateIntegrationTestAction.class);
+
+    private final KubernetesClient client;
+    private final String integrationName;
+    private final String source;
+    private final String dependencies;
+    private final String traits;
+    private final ObjectMapper mapper;
+
+    /**
+     * Constructor using given builder.
+     * @param builder
+     */
+    public CreateIntegrationTestAction(Builder builder) {
+        super("create-integration", builder);
+        this.client = builder.client;
+        this.integrationName = builder.integrationName;
+        this.source = builder.source;
+        this.dependencies = builder.dependencies;
+        this.traits = builder.traits;
+        this.mapper = builder.mapper;
+    }
+
+    @Override
+    public void doExecute(TestContext context) {
+        createIntegration(context);
+    }
+
+    private void createIntegration(TestContext context) {
+        final Integration.Builder integrationBuilder = new Integration.Builder()
+                .name(context.replaceDynamicContentInString(integrationName))
+                .source(context.replaceDynamicContentInString(source));
+
+        if (dependencies != null && !dependencies.isEmpty()) {
+            integrationBuilder.dependencies(Arrays.asList(context.replaceDynamicContentInString(dependencies).split(",")));
+        }
+
+        if (traits != null && !traits.isEmpty()) {
+            final Map<String, Integration.TraitConfig> traitConfigMap = new HashMap<>();
+            for(String t : context.replaceDynamicContentInString(traits).split(",")){
+                //traitName.key=value
+                if(!validateTraitFormat(t)) {
+                    throw new IllegalArgumentException("Trait" + t + "does not match format traitName.key=value");
+                }
+                final String[] trait = t.split("\\.",2);
+                final String[] traitConfig = trait[1].split("=", 2);
+                if(traitConfigMap.containsKey(trait[0])) {
+                    traitConfigMap.get(trait[0]).add(traitConfig[0], traitConfig[1]);
+                } else {
+                    traitConfigMap.put(trait[0],  new Integration.TraitConfig(traitConfig[0], traitConfig[1]));
+                }
+            }
+            integrationBuilder.traits(traitConfigMap);
+        }
+
+        final Integration i = integrationBuilder.build();
+
+        final CustomResourceDefinitionContext crdContext = getIntegrationCRD();
+
+        try {
+            Map<String, Object> result = client.customResource(crdContext).createOrReplace(CamelKHelper.namespace(), mapper.writeValueAsString(i));
+            if (result.get("message") != null) {
+                throw new CitrusRuntimeException(result.get("message").toString());
+            }
+        } catch (IOException e) {
+            throw new CitrusRuntimeException("Failed to create Camel-K integration via JSON object", e);
+        }
+
+        LOG.info(String.format("Successfully created Camel-K integration '%s'", i.getMetadata().getName()));
+    }
+
+    private CustomResourceDefinitionContext getIntegrationCRD() {
+        return new CustomResourceDefinitionContext.Builder()
+                .withName(Integration.CRD_INTEGRATION_NAME)
+                .withGroup(Integration.CRD_GROUP)
+                .withVersion(Integration.CRD_VERSION)
+                .withPlural("integrations")
+                .withScope("Namespaced")
+                .build();
+    }
+
+    private boolean validateTraitFormat(String trait) {
+        String patternString = "[A-Za-z-0-9]+\\.[A-Za-z-0-9]+=[A-Za-z-0-9]+";
+
+        Pattern pattern = Pattern.compile(patternString);
+
+        Matcher matcher = pattern.matcher(trait);
+        return matcher.matches();
+    }
+
+    /**
+     * Action builder.
+     */
+    public static final class Builder extends AbstractTestActionBuilder<CreateIntegrationTestAction, Builder> {
+
+        private KubernetesClient client = new DefaultKubernetesClient();
+        private String integrationName;
+        private String source;
+        private String dependencies;
+        private String traits;
+        private ObjectMapper mapper = new ObjectMapper();
+
+        /**
+         * Fluent API action building entry method used in Java DSL.
+         * @return
+         */
+        public static Builder createIntegration() {
+            return new Builder();
+        }
+
+        public Builder client(KubernetesClient client) {
+            this.client = client;
+            return this;
+        }
+
+        public Builder integrationName(String integrationName) {
+            this.integrationName = integrationName;
+            return this;
+        }
+
+        public Builder source(String source) {
+            this.source = source;
+            return this;
+        }
+
+        public Builder dependencies(String dependencies) {
+            this.dependencies = dependencies;
+            return this;
+        }
+
+        public Builder traits(String traits) {
+            this.traits = traits;
+            return this;
+        }
+
+        public Builder mapper(ObjectMapper mapper) {
+            this.mapper = mapper;
+            return this;
+        }
+
+        @Override
+        public CreateIntegrationTestAction build() {
+            return new CreateIntegrationTestAction(this);
+        }
+    }
+}

--- a/java/steps/yaks-camel-k/src/main/java/org/citrusframework/yaks/camelk/actions/VerifyIntegrationTestAction.java
+++ b/java/steps/yaks-camel-k/src/main/java/org/citrusframework/yaks/camelk/actions/VerifyIntegrationTestAction.java
@@ -1,0 +1,217 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.yaks.camelk.actions;
+
+import com.consol.citrus.AbstractTestActionBuilder;
+import com.consol.citrus.actions.AbstractTestAction;
+import com.consol.citrus.context.TestContext;
+import com.consol.citrus.exceptions.ActionTimeoutException;
+import io.fabric8.kubernetes.api.model.DoneablePod;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodList;
+import io.fabric8.kubernetes.client.DefaultKubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.dsl.PodResource;
+import org.citrusframework.yaks.camelk.CamelKHelper;
+import org.citrusframework.yaks.camelk.CamelKSettings;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Test action verifies integration Pod running state and optionally waits for a log message to be present. Raises errors
+ * when either the integration is not in running state or the log message is not available. Both operations are automatically retried
+ * for a given amount of attempts.
+ *
+ * @author Christoph Deppisch
+ */
+public class VerifyIntegrationTestAction extends AbstractTestAction {
+
+    /** Logger */
+    private static Logger LOG = LoggerFactory.getLogger(VerifyIntegrationTestAction.class);
+
+    private final KubernetesClient client;
+    private final String integrationName;
+    private final String logMessage;
+    private final int maxAttempts;
+    private final long delayBetweenAttempts;
+
+    /**
+     * Constructor using given builder.
+     * @param builder
+     */
+    public VerifyIntegrationTestAction(Builder builder) {
+        super("verify-integration", builder);
+        this.client = builder.client;
+        this.integrationName = builder.integrationName;
+        this.logMessage = builder.logMessage;
+        this.maxAttempts = builder.maxAttempts;
+        this.delayBetweenAttempts = builder.delayBetweenAttempts;
+    }
+
+    @Override
+    public void doExecute(TestContext context) {
+        String podName = context.replaceDynamicContentInString(integrationName);
+        Pod pod = verifyRunningIntegrationPod(podName);
+
+        if (logMessage != null) {
+            verifyIntegrationLogs(pod, podName, context.replaceDynamicContentInString(logMessage));
+        }
+    }
+
+    /**
+     * Wait for integration pod to log given message.
+     * @param pod
+     * @param name
+     * @param message
+     */
+    private void verifyIntegrationLogs(Pod pod, String name, String message) {
+        for (int i = 0; i < maxAttempts; i++) {
+            String log = getIntegrationPodLogs(pod);
+            if (log.contains(message)) {
+                LOG.info("Verified integration logs - All values OK!");
+                return;
+            }
+
+            LOG.warn(String.format("Waiting for integration '%s' to log message - retry in %s ms", name, delayBetweenAttempts));
+            try {
+                Thread.sleep(delayBetweenAttempts);
+            } catch (InterruptedException e) {
+                LOG.warn("Interrupted while waiting for integration pod logs", e);
+            }
+        }
+
+        throw new ActionTimeoutException(String.format("Failed to verify integration '%s' - has not printed message '%s' after %d attempts", name, logMessage, maxAttempts));
+    }
+
+    /**
+     * Retrieve log messages from given pod.
+     * @param pod
+     * @return
+     */
+    private String getIntegrationPodLogs(Pod pod) {
+        PodResource<Pod, DoneablePod> podRes = client.pods()
+                .inNamespace(CamelKHelper.namespace())
+                .withName(pod.getMetadata().getName());
+
+        String containerName = null;
+        if (pod.getSpec() != null && pod.getSpec().getContainers() != null && pod.getSpec().getContainers().size() > 1) {
+            containerName = pod.getSpec().getContainers().get(0).getName();
+        }
+
+        String logs;
+        if (containerName != null) {
+            logs = podRes.inContainer(containerName).getLog();
+        } else {
+            logs = podRes.getLog();
+        }
+        return logs;
+    }
+
+    /**
+     * Wait for given pod to be in running state.
+     * @param name
+     * @return
+     */
+    private Pod verifyRunningIntegrationPod(String name) {
+        for (int i = 0; i < maxAttempts; i++) {
+            Pod pod = getRunningIntegrationPod(name);
+            if (pod != null) {
+                LOG.info(String.format("Verified integration pod '%s' state running!", name));
+                return pod;
+            }
+
+            LOG.warn(String.format("Waiting for running integration '%s' - retry in %s ms", name, delayBetweenAttempts));
+            try {
+                Thread.sleep(delayBetweenAttempts);
+            } catch (InterruptedException e) {
+                LOG.warn("Interrupted while waiting for integration pod state", e);
+            }
+        }
+
+        throw new ActionTimeoutException(String.format("Failed to verify integration '%s' - is not running after %d attempts", name, maxAttempts));
+    }
+
+    /**
+     * Retrieve pod running state.
+     * @param integration
+     * @return
+     */
+    private Pod getRunningIntegrationPod(String integration) {
+        PodList pods = client.pods().inNamespace(CamelKHelper.namespace()).withLabel("camel.apache.org/integration", integration).list();
+        if (pods.getItems().size() == 0) {
+            return null;
+        }
+        for (Pod p : pods.getItems()) {
+            if (p.getStatus() != null && "Running".equals(p.getStatus().getPhase())) {
+                return p;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Action builder.
+     */
+    public static final class Builder extends AbstractTestActionBuilder<VerifyIntegrationTestAction, Builder> {
+
+        private KubernetesClient client = new DefaultKubernetesClient();
+        private String integrationName;
+        private String logMessage;
+
+        private int maxAttempts = CamelKSettings.getMaxAttempts();
+        private long delayBetweenAttempts = CamelKSettings.getDelayBetweenAttempts();
+
+        /**
+         * Fluent API action building entry method used in Java DSL.
+         * @return
+         */
+        public static Builder verifyIntegration() {
+            return new Builder();
+        }
+
+        public Builder client(KubernetesClient client) {
+            this.client = client;
+            return this;
+        }
+
+        public Builder isRunning(String integrationName) {
+            this.integrationName = integrationName;
+            return this;
+        }
+
+        public Builder waitForLogMessage(String logMessage) {
+            this.logMessage = logMessage;
+            return this;
+        }
+
+        public Builder maxAttempts(int maxAttempts) {
+            this.maxAttempts = maxAttempts;
+            return this;
+        }
+
+        public Builder delayBetweenAttempts(long delayBetweenAttempts) {
+            this.delayBetweenAttempts = delayBetweenAttempts;
+            return this;
+        }
+
+        @Override
+        public VerifyIntegrationTestAction build() {
+            return new VerifyIntegrationTestAction(this);
+        }
+    }
+}

--- a/java/steps/yaks-camel-k/src/main/java/org/citrusframework/yaks/camelk/model/Integration.java
+++ b/java/steps/yaks-camel-k/src/main/java/org/citrusframework/yaks/camelk/model/Integration.java
@@ -17,12 +17,12 @@
 
 package org.citrusframework.yaks.camelk.model;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
 
 public class Integration {
 
@@ -52,7 +52,7 @@ public class Integration {
 		return spec;
 	}
 
-	private static class IntegrationMetadata {
+	public static class IntegrationMetadata {
 		private String name;
 
 		public String getName() {


### PR DESCRIPTION
- Using Citrus test actions in order to support test variables, functions and other Citrus features within CamelK steps
- Add "should not print" to verify that a log message is not present

Fixes #78