### PR TITLE
fix(#60): Add possibility to run scripts before/after a test group

### DIFF
--- a/README.md
+++ b/README.md
@@ -433,6 +433,32 @@ Also we can make use of command line options when using the `yaks` binary.
 yaks test hello-world.feature --tag @regression --glue org.citrusframework.yaks
 ```
 
+## Pre/Post scripts
+
+You can run scripts before/after a test group. Just add your commands to the `yaks-config.yaml` configuration for the test group.
+
+```yaml
+config:
+  namespace:
+    temporary: false
+    autoRemove: true
+pre:
+  - script: prepare.sh
+  - run: echo Start!
+post:
+  - script: finish.sh
+  - run: echo Bye!
+```
+
+The section `pre` runs before a test group and `post` is added after the test group has finished. The post steps are run even if the tests or pre steps fail
+for some reason. This ensures that cleanup tasks are performed also in case of errors. 
+
+The `script` option provides a file path to bash script to execute. The user has to make sure that the script is executable. If no absolute file path is 
+given it is assumed to be a file path relative to the current test group directory.
+
+With `run` you can add any shell command. At the moment only single line commands are supported here. You can add multiple `run` commands in a `pre`
+or `post` section.
+
 ## For YAKS Developers
 
 Requirements:

--- a/examples/run-scripts/finish.sh
+++ b/examples/run-scripts/finish.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+echo Test finshed!

--- a/examples/run-scripts/prepare.sh
+++ b/examples/run-scripts/prepare.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+echo Now preparing the test!

--- a/examples/run-scripts/test.feature
+++ b/examples/run-scripts/test.feature
@@ -1,0 +1,4 @@
+Feature: test
+
+  Scenario: print message
+    Given print 'Hello from YAKS!'

--- a/examples/run-scripts/yaks-config.yaml
+++ b/examples/run-scripts/yaks-config.yaml
@@ -1,0 +1,10 @@
+config:
+  namespace:
+    temporary: false
+    autoRemove: true
+pre:
+  - script: prepare.sh
+  - run: echo Start!
+post:
+  - script: finish.sh
+  - run: echo Bye!

--- a/pkg/cmd/config/config.go
+++ b/pkg/cmd/config/config.go
@@ -26,16 +26,23 @@ import (
 
 type RunConfig struct {
 	Config Config `yaml:"config"`
+	Pre    []StepConfig `yaml:"pre"`
+	Post   []StepConfig `yaml:"post"`
 }
 
 type Config struct {
-	Recursive bool `yaml:"recursive"`
-	Namespace NamespaceConfig
-	Runtime   RuntimeConfig
+	Recursive 	bool `yaml:"recursive"`
+	Namespace 	NamespaceConfig
+	Runtime   	RuntimeConfig
+}
+
+type StepConfig struct {
+	Run    		string `yaml:"run"`
+	Script 		string `yaml:"script"`
 }
 
 type RuntimeConfig struct {
-	Cucumber 	CucumberConfig
+	Cucumber    CucumberConfig
 }
 
 type CucumberConfig struct {
@@ -50,7 +57,7 @@ type NamespaceConfig struct {
 	AutoRemove bool   `yaml:"autoremove"`
 }
 
-func newWithDefaults() *RunConfig {
+func NewWithDefaults() *RunConfig {
 	ns := NamespaceConfig{
 		AutoRemove: true,
 		Temporary:  false,
@@ -61,7 +68,7 @@ func newWithDefaults() *RunConfig {
 }
 
 func LoadConfig(file string) (*RunConfig, error) {
-	config := newWithDefaults()
+	config := NewWithDefaults()
 	data, err := ioutil.ReadFile(file)
 	if err != nil && os.IsNotExist(err) {
 		return config, nil


### PR DESCRIPTION
You can run scripts before/after a test group. Just add your commands to the `yaks-config.yaml` configuration for the test group.

```yaml
config:
  namespace:
    temporary: false
    autoRemove: true
pre:
  - script: prepare.sh
  - run: echo Start!
post:
  - script: finish.sh
  - run: echo Bye!
```

The section `pre` runs before a test group and `post` is added after the test group has finished. The post steps are run even if the tests or pre steps fail
for some reason. This ensures that cleanup tasks are performed also in case of errors. 

The `script` option provides a file path to bash script to execute. The user has to make sure that the script is executable. If no absolute file path is 
given it is assumed to be a file path relative to the current test group directory.

With `run` you can add any shell command. At the moment only single line commands are supported here. You can add multiple `run` commands in a `pre`
or `post` section.

Fixes #60 
Closes #55 