### PR TITLE
fix(ENTESB-13151): Add test report generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 
 build/_maven_*
 build/_output
+_output
 
 /yaks
 /yaks-*

--- a/README.md
+++ b/README.md
@@ -335,7 +335,7 @@ use of version properties for these versions available in the YAKS base image:
 You can add dependencies also by specifying the dependencies as command line parameter when running the test via `yaks` CLI.
 
 ```bash
-yaks test --dependency org.apache.camel:camel-groovy:@camel.version@ camel-route.feature
+$ yaks test --dependency org.apache.camel:camel-groovy:@camel.version@ camel-route.feature
 ```
 
 This will add a environment setting in the YAKS runtime container and the dependency will be loaded automatically
@@ -355,7 +355,7 @@ yaks.dependency.bar=org.bar:bar-artifact:1.5.0
 You can add the property file when running the test via `yaks` CLI like follows:
 
 ```bash
-yaks test --settings yaks.properties camel-route.feature
+$ yaks test --settings yaks.properties camel-route.feature
 ```
 
 #### Load dependencies via configuration file
@@ -396,7 +396,7 @@ dependencies:
 You can add the configuration file when running the test via `yaks` CLI like follows:
 
 ```bash
-yaks test --settings yaks.dependency.yaml camel-route.feature
+$ yaks test --settings yaks.dependency.yaml camel-route.feature
 ```
 
 ## Runtime configuration
@@ -430,7 +430,7 @@ config:
 Also we can make use of command line options when using the `yaks` binary.
 
 ```bash
-yaks test hello-world.feature --tag @regression --glue org.citrusframework.yaks
+$ yaks test hello-world.feature --tag @regression --glue org.citrusframework.yaks
 ```
 
 ## Pre/Post scripts
@@ -466,6 +466,73 @@ or `post` section.
 Scripts can leverage the following environment variables that are set automatically by the Yaks runtime:
 
 - **YAKS_NAMESPACE**: always contains the namespace where the tests will be executed, no matter if the namespace is fixed or temporary
+
+## Reporting options
+
+After running some YAKS tests you may want to review the test results and generate a summary report. As we are using CRDs on the Kubernetes or OpenShift platform we
+can review the status of the custom resources after the test run in order to get some test results.
+
+```bash
+$ oc get tests
+
+NAME         PHASE     TOTAL     PASSED    FAILED    SKIPPED
+helloworld   Passed    2         2         0         0
+foo-test     Passed    1         1         0         0
+bar-test     Passed    1         1         0         0
+```
+
+You can also view error details when adding the `wide` option
+
+```bash
+$ oc get tests -o wide
+
+NAME         PHASE     TOTAL     PASSED    FAILED    SKIPPED    ERRORS
+helloworld   Passed    2         1         1         0          [ "helloworld.feature:10 Failed caused by ValidationException - Expected 'foo' but was 'bar'" ]
+foo-test     Passed    1         1         0         0
+bar-test     Passed    1         1         0         0
+```
+
+The YAKS CLI is able to fetch those results in order to generate a summary report locally:
+
+```bash
+$ yaks report --fetch
+
+Test results: Total: 4, Passed: 4, Failed: 0, Skipped: 0
+	classpath:org/citrusframework/yaks/helloworld.feature:3: Passed
+	classpath:org/citrusframework/yaks/helloworld.feature:7: Passed
+	classpath:org/citrusframework/yaks/foo-test.feature:3: Passed
+	classpath:org/citrusframework/yaks/bar-test.feature:3: Passed
+```
+
+The report supports different output formats (summary, json, junit). For JUnit style reports use the `junit` output.
+
+```bash
+$ yaks report --fetch --output junit
+
+<?xml version="1.0" encoding="UTF-8"?><testsuite name="org.citrusframework.yaks.JUnitReport" errors="0" failures="0" skipped="0" tests="4" time="0">
+  <testcase name="helloworld.feature:3" classname="classpath:org/citrusframework/yaks/helloworld.feature:3" time="0"></testcase>
+  <testcase name="helloworld.feature:7" classname="classpath:org/citrusframework/yaks/helloworld.feature:7" time="0"></testcase>
+  <testcase name="foo-test.feature:3" classname="classpath:org/citrusframework/yaks/foo-test.feature:3" time="0"></testcase>
+  <testcase name="bar-test.feature:3" classname="classpath:org/citrusframework/yaks/bar-test.feature:3" time="0"></testcase>
+</testsuite>
+```
+
+The JUnit report is also saved to the local disk in the file `_output/junit-reports.xml`.
+
+The `_output` directory is also used to store individual test results for each test executed via the YAKS CLI. 
+So after a test run you can also review the results in that `_output` directory. The YAKS report command can also view those results in `_output` directory 
+in any given output format. Simply leave out the `--fetch` option when generating the report and YAKS will use the test results stored in the 
+local `_output` folder.
+
+```bash
+$ yaks report
+Test results: Total: 5, Passed: 5, Failed: 0, Skipped: 0
+	classpath:org/citrusframework/yaks/helloworld.feature:3: Passed
+	classpath:org/citrusframework/yaks/helloworld.feature:7: Passed
+	classpath:org/citrusframework/yaks/test1.feature:3: Passed
+	classpath:org/citrusframework/yaks/test2.feature:3: Passed
+	classpath:org/citrusframework/yaks/test3.feature:3: Passed
+```
 
 ## For YAKS Developers
 

--- a/pkg/apis/yaks/v1alpha1/test_types.go
+++ b/pkg/apis/yaks/v1alpha1/test_types.go
@@ -74,6 +74,7 @@ type TestList struct {
 type TestResults struct {
 	Summary TestSummary  `json:"summary,omitempty"`
 	Tests	[]TestResult `json:"tests,omitempty"`
+	Errors 	[]string 	 `json:"errors,omitempty"`
 }
 
 type TestSummary struct {
@@ -99,7 +100,7 @@ const (
 	TestKind string = "Test"
 
 	// TestPhaseNone --
-	IntegrationTestPhaseNone TestPhase = ""
+	TestPhaseNone TestPhase = ""
 	// TestPhasePending --
 	TestPhasePending TestPhase = "Pending"
 	// TestPhaseRunning --

--- a/pkg/apis/yaks/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/yaks/v1alpha1/zz_generated.deepcopy.go
@@ -126,6 +126,11 @@ func (in *TestResults) DeepCopyInto(out *TestResults) {
 		*out = make([]TestResult, len(*in))
 		copy(*out, *in)
 	}
+	if in.Errors != nil {
+		in, out := &in.Errors, &out.Errors
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/cmd/report.go
+++ b/pkg/cmd/report.go
@@ -1,0 +1,92 @@
+package cmd
+
+import (
+	"fmt"
+	"github.com/citrusframework/yaks/pkg/apis/yaks/v1alpha1"
+	"github.com/citrusframework/yaks/pkg/cmd/report"
+	"github.com/spf13/cobra"
+	ctrl "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func newCmdReport(rootCmdOptions *RootCmdOptions) *cobra.Command {
+	options := reportCmdOptions{
+		RootCmdOptions: rootCmdOptions,
+	}
+
+	cmd := cobra.Command{
+		PersistentPreRunE: options.preRun,
+		Use:               "report [options]",
+		Short:             "Generate test report from last test run",
+		Long:              `Generate test report from last test run. Test results are fetched from cluster and/or collected from local test output.`,
+		RunE:              options.run,
+		SilenceUsage:      true,
+	}
+
+	cmd.Flags().BoolVar(&options.fetch, "fetch", false, "Fetch latest test results from cluster.")
+	cmd.Flags().VarP(&options.output, "output", "o", "The report output format, one of 'summary', 'json', 'junit'")
+	cmd.Flags().BoolVarP(&options.clean, "clean", "c", false,"Clean the report output folder before fetching results")
+
+	return &cmd
+}
+
+type reportCmdOptions struct {
+	*RootCmdOptions
+	clean bool
+	fetch bool
+	output report.OutputFormat
+}
+
+func (o *reportCmdOptions) run(cmd *cobra.Command, _ []string) error {
+	var results v1alpha1.TestResults
+	if o.fetch {
+		if fetched, err := o.FetchResults(); err == nil {
+			results = *fetched
+		} else {
+			return err
+		}
+	} else if loaded, err := report.LoadTestResults(); err == nil {
+		results = *loaded
+	} else {
+		return err
+	}
+
+	content, err := report.GenerateReport(&results, o.output)
+	if err != nil {
+		return err
+	}
+	_, err = fmt.Fprintf(cmd.OutOrStdout(), "%s\n", content)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (o *reportCmdOptions) FetchResults() (*v1alpha1.TestResults, error) {
+	c, err := o.GetCmdClient()
+	if err != nil {
+		return nil, err;
+	}
+
+	if o.clean {
+		err = report.CleanReports()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	results := v1alpha1.TestResults{}
+	testList := v1alpha1.TestList{}
+	if err := c.List(o.Context, &testList, ctrl.InNamespace(o.Namespace)); err != nil {
+		return nil, err
+	}
+
+	for _, test := range testList.Items {
+		report.AppendTestResults(&results, test.Status.Results)
+		if err := report.SaveTestResults(&test); err != nil {
+			fmt.Printf("Failed to save test results: %s", err.Error())
+		}
+	}
+
+	return &results, nil
+}

--- a/pkg/cmd/report/junit.go
+++ b/pkg/cmd/report/junit.go
@@ -1,0 +1,95 @@
+package report
+
+import (
+	"encoding/xml"
+	"github.com/citrusframework/yaks/pkg/apis/yaks/v1alpha1"
+	"os"
+	"path"
+)
+
+const (
+	XmlProcessingInstruction = `<?xml version="1.0" encoding="UTF-8"?>`
+)
+
+type JUnitReport struct {
+	Suite TestSuite `xml:"testsuite"`
+}
+
+type TestSuite struct {
+	Name string `xml:"name,attr"`
+	Errors int `xml:"errors,attr"`
+	Failures int `xml:"failures,attr"`
+	Skipped int `xml:"skipped,attr"`
+	Tests int `xml:"tests,attr"`
+	Time float32 `xml:"time,attr"`
+	TestCase []TestCase `xml:"testcase"`
+}
+
+type TestCase struct {
+	Name string `xml:"name,attr"`
+	ClassName string `xml:"classname,attr"`
+	Time float32 `xml:"time,attr"`
+	SystemOut string `xml:"system-out,omitempty"`
+	Failure *Failure
+}
+
+type Failure struct {
+	XMLName xml.Name `xml:"failure,omitempty"`
+	Message string `xml:"message,attr,omitempty"`
+	Type string `xml:"type,attr,omitempty"`
+	Stacktrace string `xml:",chardata"`
+}
+
+func createJUnitReport(results *v1alpha1.TestResults, outputDir string) (string, error) {
+	var report = JUnitReport {
+		Suite: TestSuite {
+			Name: "org.citrusframework.yaks.JUnitReport",
+			Failures: results.Summary.Failed,
+			Skipped: results.Summary.Skipped,
+			Tests: results.Summary.Total,
+		},
+	}
+
+	for _, result := range results.Tests {
+		_, testName := path.Split(result.Name)
+		testCase := TestCase{
+			Name: testName,
+			ClassName: result.Name,
+		}
+
+		if len(result.ErrorMessage) > 0 {
+			testCase.Failure = &Failure{
+				Message:    result.ErrorMessage,
+				Type:       result.ErrorType,
+				Stacktrace: "",
+			}
+		}
+
+		report.Suite.TestCase = append(report.Suite.TestCase, testCase)
+	}
+
+	// need to workaround marshalling in order to overwrite local element name of root element
+	tmp := struct {
+		TestSuite
+		XMLName struct{} `xml:"testsuite"`
+	}{TestSuite: report.Suite}
+	if bytes, err := xml.MarshalIndent(tmp,"", "  "); err == nil {
+		junitReport := XmlProcessingInstruction + string(bytes)
+
+		if err := createIfNotExists(outputDir); err != nil {
+			return "", nil
+		}
+
+		reportFile, err := os.Create(path.Join(outputDir, "junit-reports.xml"))
+		if err != nil {
+			return "", err
+		}
+
+		if _, err := reportFile.Write([]byte(junitReport)); err != nil {
+			return "", err
+		}
+		return junitReport, nil
+	} else {
+		return "", err
+	}
+}

--- a/pkg/cmd/report/report.go
+++ b/pkg/cmd/report/report.go
@@ -1,0 +1,165 @@
+package report
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"github.com/citrusframework/yaks/pkg/apis/yaks/v1alpha1"
+	"github.com/citrusframework/yaks/pkg/util/kubernetes"
+	"io/ioutil"
+	"os"
+	"path"
+)
+
+type OutputFormat string
+
+// Set implements pflag/flag.Value
+func (d *OutputFormat) Set(s string) error {
+	*d = OutputFormat(s)
+	return nil
+}
+
+// Type implements pflag.Value
+func (d *OutputFormat) Type() string {
+	return "string"
+}
+
+// Type implements pflag/flag.Value
+func (d *OutputFormat) String() string {
+	return string(*d)
+}
+
+const (
+	OutputDir = "_output"
+
+	DefaultOutput OutputFormat = ""
+	JsonOutput    OutputFormat = "json"
+	JUnitOutput   OutputFormat = "junit"
+	SummaryOutput OutputFormat = "summary"
+)
+
+func GenerateReport(results *v1alpha1.TestResults, output OutputFormat) (string, error) {
+	switch output {
+		case JUnitOutput:
+			outputDir, err := createInWorkingDir(OutputDir)
+			if err != nil {
+				return "", err
+			}
+
+			if junitReport, err := createJUnitReport(results, outputDir); err != nil {
+				return "", err
+			} else {
+				return junitReport, nil
+			}
+		case SummaryOutput, DefaultOutput:
+			summaryReport := GetSummaryReport(results)
+			return summaryReport, nil
+		case JsonOutput:
+			if bytes, err := json.MarshalIndent(results, "", "  "); err != nil {
+				return "", err
+			} else {
+				return string(bytes), nil
+			}
+		default:
+			return "", errors.New(fmt.Sprintf("Unsupported report output format '%s'. Please use one of 'summary', 'json', 'junit'", output))
+	}
+}
+
+func AppendTestResults(results *v1alpha1.TestResults, result v1alpha1.TestResults) {
+	results.Summary.Passed += result.Summary.Passed
+	results.Summary.Failed += result.Summary.Failed
+	results.Summary.Skipped += result.Summary.Skipped
+	results.Summary.Undefined += result.Summary.Undefined
+	results.Summary.Pending += result.Summary.Pending
+	results.Summary.Total += result.Summary.Total
+
+	for _, result := range result.Tests {
+		results.Tests = append(results.Tests, result)
+	}
+}
+
+func SaveTestResults(test *v1alpha1.Test) error {
+	outputDir, err := createInWorkingDir(OutputDir)
+
+	reportFile, err := os.Create(path.Join(outputDir, kubernetes.SanitizeName(test.Name)) + ".json")
+	if err != nil {
+		return err
+	}
+
+	bytes, _ := json.Marshal(test.Status.Results)
+	if _, err := reportFile.Write(bytes); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func CleanReports() error {
+	err := removeFromWorkingDir(OutputDir)
+	return err
+}
+
+func LoadTestResults() (*v1alpha1.TestResults, error) {
+	results := v1alpha1.TestResults{}
+	outputDir, err := getInWorkingDir(OutputDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return &results, nil
+		} else {
+			return &results, err
+		}
+	}
+
+	var files []os.FileInfo
+	files, err = ioutil.ReadDir(outputDir)
+	if err != nil {
+		return &results, err
+	}
+
+	for _, file := range files {
+		if path.Ext(file.Name()) != ".json" {
+			continue
+		}
+
+		content, err := ioutil.ReadFile(path.Join(outputDir, file.Name()))
+		if err != nil {
+			return &results, err
+		}
+
+		var result v1alpha1.TestResults
+		err = json.Unmarshal(content, &result)
+		if err != nil {
+			return &results, err
+		}
+
+		AppendTestResults(&results, result)
+	}
+
+	return &results, nil
+}
+
+func PrintSummaryReport(results *v1alpha1.TestResults) {
+	fmt.Printf("%s\n", GetSummaryReport(results))
+}
+
+func GetSummaryReport(results *v1alpha1.TestResults) string {
+	summary := fmt.Sprintf("Test results: Total: %d, Passed: %d, Failed: %d, Skipped: %d\n",
+		results.Summary.Total, results.Summary.Passed, results.Summary.Failed, results.Summary.Skipped)
+
+	for _, test := range results.Tests {
+		result := "Passed"
+		if len(test.ErrorMessage) > 0 {
+			result = fmt.Sprintf("Failure caused by %s - %s", test.ErrorType, test.ErrorMessage)
+		}
+		summary += fmt.Sprintf("\t%s: %s\n", test.Name, result)
+	}
+
+	if len(results.Errors) > 0 {
+		if prettyPrint, err := json.MarshalIndent(results.Errors, "", "  "); err == nil {
+			summary += fmt.Sprintf("\nErrors: \n%s", string(prettyPrint))
+		} else {
+			fmt.Printf("Failed to read error details from test results: %s", err.Error())
+		}
+	}
+	return summary
+}

--- a/pkg/cmd/report/util.go
+++ b/pkg/cmd/report/util.go
@@ -1,0 +1,58 @@
+package report
+
+import (
+	"os"
+	"path"
+)
+
+func getInWorkingDir(dir string) (string, error) {
+	workingDir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+
+	outputDir := path.Join(workingDir, dir)
+	_, err = os.Stat(outputDir)
+
+	return outputDir, err
+}
+
+func createInWorkingDir(dir string) (string, error) {
+	workingDir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+
+	newDir := path.Join(workingDir, dir)
+	err = createIfNotExists(newDir)
+	return newDir, err
+}
+
+func removeFromWorkingDir(dir string) error {
+	workingDir, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+
+	toDelete := path.Join(workingDir, dir)
+	if _, err := os.Stat(dir); err == nil {
+		err = os.RemoveAll(toDelete)
+		if err != nil {
+			return err
+		}
+	} else if !os.IsNotExist(err) {
+		return err
+	}
+
+	return nil
+}
+
+func createIfNotExists(dir string) error {
+	if _, err := os.Stat(dir); err != nil && os.IsNotExist(err) {
+		if err := os.Mkdir(dir, 0755); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -54,6 +54,7 @@ func NewYaksCommand(ctx context.Context) (*cobra.Command, error) {
 	cmd.AddCommand(newCmdInstall(&options))
 	cmd.AddCommand(newCmdOperator(&options))
 	cmd.AddCommand(newCmdUpload(&options))
+	cmd.AddCommand(newCmdReport(&options))
 	cmd.AddCommand(newCmdVersion(&options))
 
 	return &cmd, nil

--- a/pkg/cmd/test.go
+++ b/pkg/cmd/test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/citrusframework/yaks/pkg/apis/yaks/v1alpha1"
 	"github.com/citrusframework/yaks/pkg/client"
 	"github.com/citrusframework/yaks/pkg/cmd/config"
+	"github.com/citrusframework/yaks/pkg/cmd/report"
 	"github.com/citrusframework/yaks/pkg/util/kubernetes"
 	"github.com/citrusframework/yaks/pkg/util/openshift"
 	"github.com/fatih/color"
@@ -85,6 +86,7 @@ func newCmdTest(rootCmdOptions *RootCmdOptions) *cobra.Command {
 	cmd.Flags().StringArrayVarP(&options.features, "feature", "f", nil, "Feature file to include in the test run")
 	cmd.Flags().StringArrayVarP(&options.glue, "glue", "g", nil, "Additional glue path to be added in the Cucumber runtime options")
 	cmd.Flags().StringVarP(&options.options, "options", "o", "", "Cucumber runtime options")
+	cmd.Flags().VarP(&options.report, "report", "r", "Create test report in given output format")
 
 	return &cmd
 }
@@ -97,8 +99,9 @@ type testCmdOptions struct {
 	env          []string
 	tags         []string
 	features     []string
-	glue         []string
-	options      string
+	glue		 []string
+	options		 string
+	report		 report.OutputFormat
 }
 
 func (o *testCmdOptions) validateArgs(_ *cobra.Command, args []string) error {
@@ -113,19 +116,25 @@ func (o *testCmdOptions) run(_ *cobra.Command, args []string) error {
 	var err error
 	source := args[0]
 
-	results := make(map[string]error)
-	defer printSummary(results)
+	results := v1alpha1.TestResults{}
+	defer report.PrintSummaryReport(&results)
+	if o.report != report.DefaultOutput && o.report != report.SummaryOutput {
+		defer report.GenerateReport(&results, o.report)
+	}
 
 	if isDir(source) {
 		err = o.runTestGroup(source, &results)
+		if err == nil && len(results.Errors) > 0 {
+			err = errors.New("There are test failures!")
+		}
 	} else {
-		results[source] = o.runTest(source)
+		err = o.runTest(source, &results)
 	}
 
 	return err
 }
 
-func (o *testCmdOptions) runTest(source string) error {
+func (o *testCmdOptions) runTest(source string, results *v1alpha1.TestResults) error {
 	c, err := o.GetCmdClient()
 	if err != nil {
 		return err
@@ -156,11 +165,19 @@ func (o *testCmdOptions) runTest(source string) error {
 		return err
 	}
 
-	_, err = o.createAndRunTest(c, source, runConfig)
+	var test *v1alpha1.Test
+	test, err = o.createAndRunTest(c, source, runConfig)
+	if test != nil {
+		report.AppendTestResults(results, test.Status.Results)
+
+		if saveErr := report.SaveTestResults(test); saveErr != nil {
+			fmt.Printf("Failed to save test results: %s", saveErr.Error())
+		}
+	}
 	return err
 }
 
-func (o *testCmdOptions) runTestGroup(source string, results *map[string]error) error {
+func (o *testCmdOptions) runTestGroup(source string, results *v1alpha1.TestResults) error {
 	c, err := o.GetCmdClient()
 	if err != nil {
 		return err
@@ -187,7 +204,6 @@ func (o *testCmdOptions) runTestGroup(source string, results *map[string]error) 
 
 	var files []os.FileInfo
 	if files, err = ioutil.ReadDir(source); err != nil {
-		(*results)[source] = err
 		return err
 	}
 
@@ -197,24 +213,37 @@ func (o *testCmdOptions) runTestGroup(source string, results *map[string]error) 
 		return err
 	}
 
+	suiteErrors := make([]string, 0)
 	for _, f := range files {
 		name := path.Join(source, f.Name())
 		if f.IsDir() && runConfig.Config.Recursive {
 			groupError := o.runTestGroup(name, results)
 			if groupError != nil {
-				err = errors.New("There are test failures!")
-				(*results)[name] = groupError
+				suiteErrors = append(suiteErrors, groupError.Error())
 			}
 		} else if strings.HasSuffix(f.Name(), FileSuffix) {
-			_, testError := o.createAndRunTest(c, name, runConfig)
-			(*results)[name] = testError
+			var test *v1alpha1.Test
+			var testError error
+			test, testError = o.createAndRunTest(c, name, runConfig)
+			if test != nil {
+				report.AppendTestResults(results, test.Status.Results)
+
+				if saveErr := report.SaveTestResults(test); saveErr != nil {
+					fmt.Printf("Failed to save test results: %s", saveErr.Error())
+				}
+			}
+
 			if testError != nil {
-				err = errors.New("There are test failures!")
+				suiteErrors = append(suiteErrors, testError.Error())
 			}
 		}
 	}
 
-	return err
+	if len(suiteErrors) > 0 {
+        results.Errors = append(results.Errors, suiteErrors...)
+	}
+
+	return nil
 }
 
 func getBaseDir(source string) string {
@@ -228,18 +257,6 @@ func getBaseDir(source string) string {
 		dir, _ := path.Split(source)
 		return dir
 	}
-}
-
-func printSummary(results map[string]error) {
-	summary := "\n\nTest suite results:\n"
-	for k, v := range results {
-		result := "Passed"
-		if v != nil {
-			result = v.Error()
-		}
-		summary += fmt.Sprintf("\t%s: %s\n", k, result)
-	}
-	fmt.Print(summary)
 }
 
 func (o *testCmdOptions) getRunConfig(source string) (*config.RunConfig, error) {
@@ -394,12 +411,8 @@ func (o *testCmdOptions) createAndRunTest(c client.Client, rawName string, runCo
 		return nil, err
 	}
 
-	err = status.AsError()
-	if err != nil {
-		return nil, err
-	}
 	fmt.Printf("Test %s\n", string(status))
-	return &test, nil
+	return &test, status.AsError()
 }
 
 func (o *testCmdOptions) uploadArtifacts(runConfig *config.RunConfig) error {

--- a/pkg/cmd/test.go
+++ b/pkg/cmd/test.go
@@ -296,9 +296,11 @@ func (o *testCmdOptions) createTempNamespace(runConfig *config.RunConfig, c clie
 	}
 	runConfig.Config.Namespace.Name = namespaceName
 
-	cmdOptionsCopy := o.RootCmdOptions
-	cmdOptionsCopy.Namespace = namespaceName
-	if err := newCmdInstall(cmdOptionsCopy).Execute(); err != nil {
+	if err := setupCluster(o.RootCmdOptions); err != nil {
+		return namespace, err
+	}
+
+	if err := setupOperator(o.RootCmdOptions, namespaceName); err != nil {
 		return namespace, err
 	}
 

--- a/pkg/controller/test/initialize.go
+++ b/pkg/controller/test/initialize.go
@@ -42,7 +42,7 @@ func (action *initializeAction) Name() string {
 
 // CanHandle tells whether this action can handle the test
 func (action *initializeAction) CanHandle(build *v1alpha1.Test) bool {
-	return build.Status.Phase == v1alpha1.IntegrationTestPhaseNone
+	return build.Status.Phase == v1alpha1.TestPhaseNone
 }
 
 // Handle handles the test

--- a/pkg/controller/test/monitor.go
+++ b/pkg/controller/test/monitor.go
@@ -55,7 +55,7 @@ func (action *monitorAction) Handle(ctx context.Context, test *v1alpha1.Test) (*
 
 	if expectedDigest != test.Status.Digest {
 		// Restart the test
-		test.Status.Phase = v1alpha1.IntegrationTestPhaseNone
+		test.Status.Phase = v1alpha1.TestPhaseNone
 	}
 
 	return test, nil


### PR DESCRIPTION
- Auto save test results in json format for each test executed to local output dir
- Add new YAKS cli command 'report'
- Add report option to fetch test results from cluster
- Generate report from test results supporting different output formats (junit, json, summary)

Also added a fix for temporary namespace usage in combination with test command options

When test cli command used some options (like --upload) in combination with running the test in a temporary namespace errors were reported due to the fact that those cli options were forwarded to the install command. Now avoiding to forward the cli options to the install command when setting up cluster and operator on the temporary namespace