### PR TITLE
Yaks CLI fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -463,6 +463,10 @@ given it is assumed to be a file path relative to the current test group directo
 With `run` you can add any shell command. At the moment only single line commands are supported here. You can add multiple `run` commands in a `pre`
 or `post` section.
 
+Scripts can leverage the following environment variables that are set automatically by the Yaks runtime:
+
+- **YAKS_NAMESPACE**: always contains the namespace where the tests will be executed, no matter if the namespace is fixed or temporary
+
 ## For YAKS Developers
 
 Requirements:

--- a/README.md
+++ b/README.md
@@ -445,6 +445,10 @@ config:
 pre:
   - script: prepare.sh
   - run: echo Start!
+  - run: |
+      echo "Multiline"
+      echo "Commands are also"
+      echo "Supported!"
 post:
   - script: finish.sh
   - run: echo Bye!

--- a/pkg/cmd/test.go
+++ b/pkg/cmd/test.go
@@ -580,8 +580,12 @@ func runSteps(steps []config.StepConfig, namespace, baseDir string) error {
 
 func runScript(scriptFile, desc, namespace, baseDir string) error {
 	command := exec.Command(scriptFile)
+
 	command.Env = os.Environ()
 	command.Env = append(command.Env, fmt.Sprintf("YAKS_NAMESPACE=%s", namespace))
+
+	command.Dir = baseDir
+
 	if out, err := command.Output(); err == nil {
 		fmt.Printf("Running %s: \n%s\n", desc, out)
 	} else {

--- a/pkg/cmd/test.go
+++ b/pkg/cmd/test.go
@@ -579,7 +579,10 @@ func runSteps(steps []config.StepConfig, namespace, baseDir string) error {
 }
 
 func runScript(scriptFile, desc, namespace, baseDir string) error {
-	if out, err := exec.Command(scriptFile).Output(); err == nil {
+	command := exec.Command(scriptFile)
+	command.Env = os.Environ()
+	command.Env = append(command.Env, fmt.Sprintf("YAKS_NAMESPACE=%s", namespace))
+	if out, err := command.Output(); err == nil {
 		fmt.Printf("Running %s: \n%s\n", desc, out)
 	} else {
 		fmt.Printf("Failed to run %s: \n%v\n", desc, err)


### PR DESCRIPTION
This contains some improvements for the CLI:

- support for multiline scripts in run
- injection of the YAKS_NAMESPACE environment variable
- using a consistent base dir for the script
