### PR TITLE
fix(#92): Add waitFor Http URL condition step

### DIFF
--- a/java/steps/yaks-http/src/test/java/org/citrusframework/yaks/http/HttpEndpointConfiguration.java
+++ b/java/steps/yaks-http/src/test/java/org/citrusframework/yaks/http/HttpEndpointConfiguration.java
@@ -62,6 +62,7 @@ public class HttpEndpointConfiguration {
         Map<String, EndpointAdapter> mappings = new HashMap<>();
 
         mappings.put(HttpMethod.GET.name(), handleGetRequestAdapter(contextFactory));
+        mappings.put(HttpMethod.HEAD.name(), handleHeadRequestAdapter(contextFactory));
         mappings.put(HttpMethod.POST.name(), handlePostRequestAdapter());
         mappings.put(HttpMethod.PUT.name(), handlePutRequestAdapter());
         mappings.put(HttpMethod.DELETE.name(), handleDeleteRequestAdapter());
@@ -101,6 +102,15 @@ public class HttpEndpointConfiguration {
         responseEndpointAdapter.getMessageHeader().put(HttpMessageHeaders.HTTP_CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE);
         responseEndpointAdapter.getMessageHeader().put("X-TodoId", "citrus:randomNumber(5)");
         responseEndpointAdapter.setMessagePayload("{\"id\": \"citrus:randomNumber(5)\", \"task\": \"Sample task\", \"completed\": 0}");
+        responseEndpointAdapter.setTestContextFactory(contextFactory);
+        return responseEndpointAdapter;
+    }
+
+    @Bean
+    public EndpointAdapter handleHeadRequestAdapter(TestContextFactory contextFactory) {
+        StaticResponseEndpointAdapter responseEndpointAdapter = new StaticResponseEndpointAdapter();
+        responseEndpointAdapter.getMessageHeader().put(HttpMessageHeaders.HTTP_CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE);
+        responseEndpointAdapter.getMessageHeader().put("X-TodoId", "citrus:randomNumber(5)");
         responseEndpointAdapter.setTestContextFactory(contextFactory);
         return responseEndpointAdapter;
     }

--- a/java/steps/yaks-http/src/test/resources/org/citrusframework/yaks/http/http.client.feature
+++ b/java/steps/yaks-http/src/test/resources/org/citrusframework/yaks/http/http.client.feature
@@ -4,6 +4,14 @@ Feature: Http client
     Given variable port is "8080"
     Given URL: http://localhost:${port}
 
+  Scenario: Health check
+    And URL is healthy
+
+  Scenario: Wait for Http URL condition
+    Given HTTP request timeout is 5000 milliseconds
+    Then wait for URL http://localhost:${port}/todo to return 200 OK
+    And wait for GET on URL http://localhost:${port}/todo
+
   Scenario: GET
     When send GET /todo
     Then verify HTTP response body: {"id": "@ignore@", "task": "Sample task", "completed": 0}


### PR DESCRIPTION
Add step to wait for a given URL to return a Http status. This implements a sort of health check on a given endpoint URL. The wait step polls on the endpoint URL with a given interval. Users can set the basic Http request timeout in milliseconds.

Sample usage in a feature:
```gherkin
Background:
    Given variable port is "8080"
    Given URL: http://localhost:${port}

  Scenario: Health check
    And URL is healthy

  Scenario: Wait for Http URL condition
    Given HTTP request timeout is 5000 milliseconds
    Then wait for URL http://localhost:${port}/todo to return 200 OK
    And wait for GET on URL http://localhost:${port}/todo
```