### PR TITLE
fix(#101): Wait for Http resource path

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ YAKS Cloud-Native BDD testing or simply: Yet Another Kubernetes Service
   * Apache Camel Steps
   * [Camel K Steps](#camel-k-steps)
   * [JDBC Steps](#jdbc-steps)
-  * Http Steps
+  * [Http Steps](#http-steps)
   * [Open API Steps](#openapi-steps)
   * Kafka Steps
   * Jms Steps
@@ -281,6 +281,62 @@ You can find examples of JDBC steps in the [examples](/examples/jdbc.feature) fi
 
 There's also an example that uses [JDBC and REST together](/examples/task-api.feature) and targets the 
 [Syndesis TODO App](https://github.com/syndesisio/todo-example) database.
+
+### Http steps
+
+The Http protocol is a widely used communication protocol when it comes to exchanging data between systems. REST Http services 
+are very prominent and producing/consuming those services is a common task in software development these days. YAKS provides
+ready to use steps that are able to exchange request/response messages via Http during the test.
+
+As a client you can specify the server URL and send requests to it.
+
+```gherkin
+Feature: Http client
+
+  Background:
+    Given URL: http://localhost:8080
+
+  Scenario: Health check
+    Given path /health is healthy
+
+  Scenario: GET request
+    When send GET /todo
+    Then verify HTTP response body: {"id": "@ignore@", "task": "Sample task", "completed": 0}
+    And receive HTTP 200 OK
+```
+
+The example above sets a base request URL to `http://localhost:8080` and performs a health check on path `/health`. After that we can
+send any request to the server and verify the response body and status code.
+
+All these steps are part of the core YAKS framework and you can just use them.
+
+On the server side we can start a new Http server instance on a given port and listen for incoming requests. These request can be verified and
+the test can provide a simulated response message with body and header data.
+
+```gherkin
+Feature: Http server
+
+  Background:
+    Given HTTP server listening on port 8080 
+
+  Scenario: Expect GET request
+    When receive GET /todo
+    Then HTTP response body:  {"id": 1000, "task": "Sample task", "completed": 0}
+    And send HTTP 200 OK
+
+  Scenario: Expect POST request
+    Given expect HTTP request body: {"id": "@isNumber()@", "task": "New task", "completed": "@matches(0|1)@"}
+    When receive POST /todo
+    Then send HTTP 201 CREATED
+```
+
+In the HTTP server sample above we create a new server instance listening on port `8080`. Then we expect a `GET` request on path `/todo`. The server responds with
+a Http `200 OK` response message and given Json body as payload.
+
+The second scenario expects a POST request with a given body as Json payload. The expected request payload is verified with the powerful Citrus JSON 
+message validator being able to compare JSON tree structures in combination with validation matchers such as `isNumber()` or `matches(0|1)`.
+
+Once the request is verified the server responds with a simple Http `201 CREATED`. 
 
 ### OpenAPI steps
 

--- a/java/steps/yaks-http/src/main/java/org/citrusframework/yaks/http/HttpServerSteps.java
+++ b/java/steps/yaks-http/src/main/java/org/citrusframework/yaks/http/HttpServerSteps.java
@@ -85,13 +85,22 @@ public class HttpServerSteps implements HttpSteps {
         bodyValidationExpressions = new HashMap<>();
     }
 
-    @Given("^http-server \"([^\"\\s]+)\"$")
+    @Given("^HTTP server \"([^\"\\s]+)\"$")
     public void setServer(String id) {
         if (!citrus.getCitrusContext().getReferenceResolver().isResolvable(id)) {
             throw new CitrusRuntimeException("Unable to find http server for id: " + id);
         }
 
         httpServer = citrus.getCitrusContext().getReferenceResolver().resolve(id, HttpServer.class);
+    }
+
+    @Given("^HTTP server listening on port (\\d+)$")
+    public void createServer(int port) {
+        httpServer = new HttpServerBuilder()
+                .port(port)
+                .build();
+
+        httpServer.start();
     }
 
     @Then("^(?:expect|verify) HTTP request header: ([^\\s]+)(?:=| is )\"(.+)\"$")

--- a/java/steps/yaks-http/src/test/resources/org/citrusframework/yaks/http/http.client.feature
+++ b/java/steps/yaks-http/src/test/resources/org/citrusframework/yaks/http/http.client.feature
@@ -5,12 +5,18 @@ Feature: Http client
     Given URL: http://localhost:${port}
 
   Scenario: Health check
-    And URL is healthy
+    Given URL is healthy
+    And URL http://localhost:${port}/todo is healthy
+    And path /todo is healthy
 
   Scenario: Wait for Http URL condition
     Given HTTP request timeout is 5000 milliseconds
     Then wait for URL http://localhost:${port}/todo to return 200 OK
+    And wait for path /todo to return 200 OK
+    And wait for GET on URL http://localhost:${port}/todo to return 200 OK
+    And wait for GET on URL /todo to return 200 OK
     And wait for GET on URL http://localhost:${port}/todo
+    And wait for GET on path /todo
 
   Scenario: GET
     When send GET /todo


### PR DESCRIPTION
- Support both full request URL and relative resource path when doing a Http health check
- Add Http steps documentation to README
- Fix http-server and http-client step wording to be compliant with other steps
- Add "HTTP server listening on port {port}" step to create new server instance

Fixes #101 