### PR TITLE
chore: Reduce 3rd party dependencies

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -35,6 +35,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
+    <slf4j.version>1.7.30</slf4j.version>
     <log4j2.version>2.13.1</log4j2.version>
     <citrus.version>3.0.0-M1</citrus.version>
     <spring.version>5.2.4.RELEASE</spring.version>
@@ -81,7 +82,32 @@
       <!-- Citrus -->
       <dependency>
         <groupId>com.consol.citrus</groupId>
-        <artifactId>citrus-core</artifactId>
+        <artifactId>citrus-base</artifactId>
+        <version>${citrus.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.consol.citrus</groupId>
+        <artifactId>citrus-core-spring</artifactId>
+        <version>${citrus.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.consol.citrus</groupId>
+        <artifactId>citrus-validation-json</artifactId>
+        <version>${citrus.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.consol.citrus</groupId>
+        <artifactId>citrus-validation-text</artifactId>
+        <version>${citrus.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.consol.citrus</groupId>
+        <artifactId>citrus-validation-groovy</artifactId>
+        <version>${citrus.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.consol.citrus</groupId>
+        <artifactId>citrus-validation-hamcrest</artifactId>
         <version>${citrus.version}</version>
       </dependency>
       <dependency>
@@ -122,11 +148,40 @@
         <version>${cucumber.version}</version>
       </dependency>
 
+      <!-- Spring Framework -->
+      <dependency>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-beans</artifactId>
+        <version>${spring.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-aop</artifactId>
+        <version>${spring.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-tx</artifactId>
+        <version>${spring.version}</version>
+      </dependency>
+
+      <!-- Apache Camel -->
+      <dependency>
+        <groupId>org.apache.camel</groupId>
+        <artifactId>camel-core</artifactId>
+        <version>${camel.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.camel</groupId>
+        <artifactId>camel-spring</artifactId>
+        <version>${camel.version}</version>
+      </dependency>
+
       <!-- Logging -->
       <dependency>
-        <groupId>org.apache.logging.log4j</groupId>
-        <artifactId>log4j-slf4j-impl</artifactId>
-        <version>${log4j2.version}</version>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-api</artifactId>
+        <version>${slf4j.version}</version>
       </dependency>
 
       <dependency>
@@ -140,7 +195,19 @@
         <version>${jackson.version}</version>
       </dependency>
 
+      <dependency>
+        <groupId>org.yaml</groupId>
+        <artifactId>snakeyaml</artifactId>
+        <version>1.25</version>
+      </dependency>
+
       <!-- Unit testing -->
+      <dependency>
+        <groupId>org.apache.logging.log4j</groupId>
+        <artifactId>log4j-slf4j-impl</artifactId>
+        <version>${log4j2.version}</version>
+        <scope>test</scope>
+      </dependency>
       <dependency>
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
@@ -151,14 +218,52 @@
         <groupId>org.assertj</groupId>
         <artifactId>assertj-core</artifactId>
         <version>${assertj-core.version}</version>
+        <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-core</artifactId>
         <version>${mockito.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.postgresql</groupId>
+        <artifactId>postgresql</artifactId>
+        <version>${postgresql.version}</version>
+        <scope>test</scope>
       </dependency>
     </dependencies>
   </dependencyManagement>
+
+  <dependencies>
+    <!-- Global dependencies -->
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+
+    <!-- Test scope -->
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-slf4j-impl</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
 
   <build>
     <pluginManagement>

--- a/java/runtime/yaks-runtime-maven/pom.xml
+++ b/java/runtime/yaks-runtime-maven/pom.xml
@@ -92,6 +92,21 @@
 
     <!-- ****************************** -->
     <!--                                -->
+    <!-- DEFAULT VALIDATION MODULES     -->
+    <!--                                -->
+    <!-- ****************************** -->
+
+    <dependency>
+      <groupId>com.consol.citrus</groupId>
+      <artifactId>citrus-validation-json</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.consol.citrus</groupId>
+      <artifactId>citrus-validation-text</artifactId>
+    </dependency>
+
+    <!-- ****************************** -->
+    <!--                                -->
     <!-- OTHERS                         -->
     <!--                                -->
     <!-- ****************************** -->
@@ -99,13 +114,13 @@
     <dependency>
       <groupId>io.cucumber</groupId>
       <artifactId>cucumber-junit</artifactId>
+      <scope>test</scope>
     </dependency>
-
     <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-slf4j-impl</artifactId>
+      <groupId>com.consol.citrus</groupId>
+      <artifactId>citrus-core-spring</artifactId>
+      <scope>test</scope>
     </dependency>
-
   </dependencies>
 
 </project>

--- a/java/steps/yaks-camel-k/pom.xml
+++ b/java/steps/yaks-camel-k/pom.xml
@@ -36,7 +36,7 @@
 
     <dependency>
       <groupId>com.consol.citrus</groupId>
-      <artifactId>citrus-core</artifactId>
+      <artifactId>citrus-base</artifactId>
     </dependency>
     <dependency>
       <groupId>com.consol.citrus</groupId>
@@ -52,12 +52,6 @@
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
     </dependency>
-
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-    </dependency>
-
   </dependencies>
 
 </project>

--- a/java/steps/yaks-camel/pom.xml
+++ b/java/steps/yaks-camel/pom.xml
@@ -36,7 +36,7 @@
 
     <dependency>
       <groupId>com.consol.citrus</groupId>
-      <artifactId>citrus-core</artifactId>
+      <artifactId>citrus-base</artifactId>
     </dependency>
     <dependency>
       <groupId>com.consol.citrus</groupId>
@@ -46,36 +46,26 @@
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-beans</artifactId>
-      <version>${spring.version}</version>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-aop</artifactId>
-      <version>${spring.version}</version>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-tx</artifactId>
-      <version>${spring.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-core</artifactId>
-      <version>${camel.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring</artifactId>
-      <version>${camel.version}</version>
     </dependency>
 
     <!-- Test scope -->
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
     <dependency>
       <groupId>io.cucumber</groupId>
       <artifactId>cucumber-junit</artifactId>
@@ -87,8 +77,13 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-slf4j-impl</artifactId>
+      <groupId>com.consol.citrus</groupId>
+      <artifactId>citrus-core-spring</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.consol.citrus</groupId>
+      <artifactId>citrus-validation-text</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/java/steps/yaks-http/pom.xml
+++ b/java/steps/yaks-http/pom.xml
@@ -36,7 +36,7 @@
 
     <dependency>
       <groupId>com.consol.citrus</groupId>
-      <artifactId>citrus-core</artifactId>
+      <artifactId>citrus-base</artifactId>
     </dependency>
     <dependency>
       <groupId>com.consol.citrus</groupId>
@@ -44,11 +44,6 @@
     </dependency>
 
     <!-- Test scope -->
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
     <dependency>
       <groupId>io.cucumber</groupId>
       <artifactId>cucumber-junit</artifactId>
@@ -60,8 +55,13 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-slf4j-impl</artifactId>
+      <groupId>com.consol.citrus</groupId>
+      <artifactId>citrus-core-spring</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.consol.citrus</groupId>
+      <artifactId>citrus-validation-json</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/java/steps/yaks-http/src/test/resources/citrus-application.properties
+++ b/java/steps/yaks-http/src/test/resources/citrus-application.properties
@@ -16,3 +16,4 @@
 #
 
 citrus.spring.java.config=org.citrusframework.yaks.http.HttpEndpointConfiguration
+citrus.default.message.type=JSON

--- a/java/steps/yaks-jdbc/pom.xml
+++ b/java/steps/yaks-jdbc/pom.xml
@@ -29,7 +29,6 @@
   <name>YAKS :: Steps :: JDBC</name>
 
   <dependencies>
-
     <dependency>
       <groupId>io.cucumber</groupId>
       <artifactId>cucumber-java</artifactId>
@@ -37,21 +36,10 @@
 
     <dependency>
       <groupId>com.consol.citrus</groupId>
-      <artifactId>citrus-core</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.postgresql</groupId>
-      <artifactId>postgresql</artifactId>
-      <version>${postgresql.version}</version>
+      <artifactId>citrus-base</artifactId>
     </dependency>
 
     <!-- Test scope -->
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
     <dependency>
       <groupId>io.cucumber</groupId>
       <artifactId>cucumber-junit</artifactId>
@@ -60,6 +48,16 @@
     <dependency>
       <groupId>com.consol.citrus</groupId>
       <artifactId>citrus-cucumber</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.consol.citrus</groupId>
+      <artifactId>citrus-core-spring</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.consol.citrus</groupId>
+      <artifactId>citrus-validation-groovy</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -75,11 +73,10 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-slf4j-impl</artifactId>
+      <groupId>org.postgresql</groupId>
+      <artifactId>postgresql</artifactId>
       <scope>test</scope>
     </dependency>
-
   </dependencies>
 
 </project>

--- a/java/steps/yaks-jdbc/src/main/java/org/citrusframework/yaks/jdbc/JdbcSteps.java
+++ b/java/steps/yaks-jdbc/src/main/java/org/citrusframework/yaks/jdbc/JdbcSteps.java
@@ -34,7 +34,6 @@ import io.cucumber.java.Scenario;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
-import org.postgresql.Driver;
 import org.springframework.jdbc.datasource.SingleConnectionDataSource;
 
 import static com.consol.citrus.actions.ExecuteSQLAction.Builder.sql;
@@ -74,8 +73,8 @@ public class JdbcSteps {
     public void setConnection(DataTable properties) {
         Map<String, String> connectionProps = properties.asMap(String.class, String.class);
 
-        String driver = connectionProps.getOrDefault("driver", Driver.class.getName());
-        String url = connectionProps.getOrDefault("url", "");
+        String driver = connectionProps.getOrDefault("driver", "org.postgresql.Driver");
+        String url = connectionProps.getOrDefault("url", "jdbc:postgresql://localhost:5432/testdb");
         String username = connectionProps.getOrDefault("username", "test");
         String password = connectionProps.getOrDefault("password", "test");
         boolean suppressClose = Boolean.parseBoolean(connectionProps.getOrDefault("suppressClose", Boolean.TRUE.toString()));

--- a/java/steps/yaks-jdbc/src/test/java/org/citrusframework/yaks/jdbc/JdbcStepsTest.java
+++ b/java/steps/yaks-jdbc/src/test/java/org/citrusframework/yaks/jdbc/JdbcStepsTest.java
@@ -17,9 +17,6 @@
 
 package org.citrusframework.yaks.jdbc;
 
-import java.util.function.Consumer;
-
-import com.github.dockerjava.api.command.CreateContainerCmd;
 import com.github.dockerjava.api.model.ExposedPort;
 import com.github.dockerjava.api.model.PortBinding;
 import com.github.dockerjava.api.model.Ports;
@@ -27,7 +24,6 @@ import io.cucumber.junit.Cucumber;
 import io.cucumber.junit.CucumberOptions;
 import org.junit.ClassRule;
 import org.junit.runner.RunWith;
-import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.PostgreSQLContainer;
 
 /**
@@ -42,12 +38,12 @@ import org.testcontainers.containers.PostgreSQLContainer;
 public class JdbcStepsTest {
 
     @ClassRule
-    public static GenericContainer testdbContainer = new PostgreSQLContainer()
+    public static PostgreSQLContainer<?> testdbContainer = new PostgreSQLContainer<>()
             .withDatabaseName("testdb")
             .withUsername("test")
             .withPassword("secret")
             .withInitScript("test-db-init.sql")
-            .withCreateContainerCmdModifier((Consumer<CreateContainerCmd>) modifier -> modifier.withPortBindings(
+            .withCreateContainerCmdModifier(modifier -> modifier.withPortBindings(
                     new PortBinding(Ports.Binding.bindPort(PostgreSQLContainer.POSTGRESQL_PORT),
                     new ExposedPort(PostgreSQLContainer.POSTGRESQL_PORT))));
 }

--- a/java/steps/yaks-jms/pom.xml
+++ b/java/steps/yaks-jms/pom.xml
@@ -67,22 +67,20 @@
 
     <dependency>
       <groupId>com.consol.citrus</groupId>
-      <artifactId>citrus-core</artifactId>
+      <artifactId>citrus-base</artifactId>
     </dependency>
-
     <dependency>
       <groupId>com.consol.citrus</groupId>
       <artifactId>citrus-jms</artifactId>
     </dependency>
 
-    <!-- Provided scope dependencies -->
+    <!-- JMS connection factory dependencies in provided scope -->
     <dependency>
       <groupId>org.apache.activemq</groupId>
       <artifactId>activemq-client</artifactId>
       <version>${activemq.version}</version>
       <scope>provided</scope>
     </dependency>
-
     <dependency>
       <groupId>org.apache.activemq</groupId>
       <artifactId>artemis-jms-client</artifactId>
@@ -91,11 +89,6 @@
     </dependency>
 
     <!-- Test scoped dependencies -->
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
     <dependency>
       <groupId>io.cucumber</groupId>
       <artifactId>cucumber-junit</artifactId>
@@ -107,18 +100,18 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-slf4j-impl</artifactId>
+      <groupId>com.consol.citrus</groupId>
+      <artifactId>citrus-core-spring</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.assertj</groupId>
-      <artifactId>assertj-core</artifactId>
+      <groupId>com.consol.citrus</groupId>
+      <artifactId>citrus-validation-json</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
+      <groupId>com.consol.citrus</groupId>
+      <artifactId>citrus-validation-text</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/java/steps/yaks-kafka/pom.xml
+++ b/java/steps/yaks-kafka/pom.xml
@@ -36,20 +36,14 @@
 
     <dependency>
       <groupId>com.consol.citrus</groupId>
-      <artifactId>citrus-core</artifactId>
+      <artifactId>citrus-base</artifactId>
     </dependency>
-
     <dependency>
       <groupId>com.consol.citrus</groupId>
       <artifactId>citrus-kafka</artifactId>
     </dependency>
 
     <!-- Test scope -->
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
     <dependency>
       <groupId>io.cucumber</groupId>
       <artifactId>cucumber-junit</artifactId>
@@ -61,8 +55,18 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-slf4j-impl</artifactId>
+      <groupId>com.consol.citrus</groupId>
+      <artifactId>citrus-core-spring</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.consol.citrus</groupId>
+      <artifactId>citrus-validation-json</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.consol.citrus</groupId>
+      <artifactId>citrus-validation-text</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/java/steps/yaks-openapi/pom.xml
+++ b/java/steps/yaks-openapi/pom.xml
@@ -48,15 +48,14 @@
 
     <dependency>
       <groupId>com.consol.citrus</groupId>
-      <artifactId>citrus-core</artifactId>
+      <artifactId>citrus-base</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.consol.citrus</groupId>
+      <artifactId>citrus-validation-json</artifactId>
     </dependency>
 
     <!-- Test scope -->
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
     <dependency>
       <groupId>io.cucumber</groupId>
       <artifactId>cucumber-junit</artifactId>
@@ -68,8 +67,13 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-slf4j-impl</artifactId>
+      <groupId>com.consol.citrus</groupId>
+      <artifactId>citrus-core-spring</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.consol.citrus</groupId>
+      <artifactId>citrus-validation-hamcrest</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/java/steps/yaks-openapi/src/main/java/org/citrusframework/yaks/openapi/OpenApiSteps.java
+++ b/java/steps/yaks-openapi/src/main/java/org/citrusframework/yaks/openapi/OpenApiSteps.java
@@ -32,6 +32,7 @@ import com.consol.citrus.TestCaseRunner;
 import com.consol.citrus.annotations.CitrusAnnotations;
 import com.consol.citrus.annotations.CitrusFramework;
 import com.consol.citrus.annotations.CitrusResource;
+import com.consol.citrus.variable.dictionary.AbstractDataDictionary;
 import com.consol.citrus.variable.dictionary.json.JsonPathMappingDataDictionary;
 import io.apicurio.datamodels.openapi.models.OasDocument;
 import io.apicurio.datamodels.openapi.models.OasOperation;
@@ -64,8 +65,8 @@ public class OpenApiSteps {
     private OasDocument openApiDoc;
     private OasOperation operation;
 
-    private JsonPathMappingDataDictionary outboundDictionary;
-    private JsonPathMappingDataDictionary inboundDictionary;
+    private AbstractDataDictionary<String> outboundDictionary;
+    private AbstractDataDictionary<String> inboundDictionary;
 
     @Before
     public void before(Scenario scenario) {

--- a/java/steps/yaks-openapi/src/test/resources/citrus-application.properties
+++ b/java/steps/yaks-openapi/src/test/resources/citrus-application.properties
@@ -16,3 +16,4 @@
 #
 
 citrus.spring.java.config=org.citrusframework.yaks.openapi.PetstoreConfiguration
+citrus.default.message.type=JSON

--- a/java/steps/yaks-standard/pom.xml
+++ b/java/steps/yaks-standard/pom.xml
@@ -36,7 +36,7 @@
 
     <dependency>
       <groupId>com.consol.citrus</groupId>
-      <artifactId>citrus-core</artifactId>
+      <artifactId>citrus-base</artifactId>
     </dependency>
     <dependency>
       <groupId>com.consol.citrus</groupId>
@@ -54,23 +54,13 @@
 
     <!-- Test scope -->
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.assertj</groupId>
-      <artifactId>assertj-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>io.cucumber</groupId>
       <artifactId>cucumber-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-slf4j-impl</artifactId>
+      <groupId>com.consol.citrus</groupId>
+      <artifactId>citrus-core-spring</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/java/tools/maven/yaks-maven-extension/pom.xml
+++ b/java/tools/maven/yaks-maven-extension/pom.xml
@@ -99,24 +99,11 @@
     <dependency>
       <groupId>org.yaml</groupId>
       <artifactId>snakeyaml</artifactId>
-      <version>1.25</version>
     </dependency>
 
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-    </dependency>
-
-    <!-- Test scope -->
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.assertj</groupId>
-      <artifactId>assertj-core</artifactId>
-      <scope>test</scope>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
Only depend on those Citrus modules that we really need at runtime. Other dependencies will be added to the individual test configurations. This makes the YAKS image smaller and avoids that unused modules are loaded at startup.