### PR TITLE
chore: Use YAKS standard steps instead of those provided by Citrus

### DIFF
--- a/java/runtime/yaks-runtime-maven/src/test/java/org/citrusframework/yaks/YaksTest.java
+++ b/java/runtime/yaks-runtime-maven/src/test/java/org/citrusframework/yaks/YaksTest.java
@@ -24,7 +24,6 @@ import org.junit.runner.RunWith;
 @RunWith(Cucumber.class)
 @CucumberOptions(
         strict = true,
-        extraGlue = { "com.consol.citrus.cucumber.step.runner.core" },
         plugin = { "pretty", "org.citrusframework.yaks.report.TestReporter" }
 )
 public class YaksTest {

--- a/java/steps/yaks-camel/src/main/java/org/citrusframework/yaks/camel/CamelSteps.java
+++ b/java/steps/yaks-camel/src/main/java/org/citrusframework/yaks/camel/CamelSteps.java
@@ -137,7 +137,7 @@ public class CamelSteps {
                 ClassLoader cl = Thread.currentThread().getContextClassLoader();
                 GroovyShell sh = new GroovyShell(cl, new Binding(), cc);
 
-                 DelegatingScript script = (DelegatingScript) sh.parse(route);
+                DelegatingScript script = (DelegatingScript) sh.parse(route);
 
                 // set the delegate target
                 script.setDelegate(this);

--- a/java/steps/yaks-http/pom.xml
+++ b/java/steps/yaks-http/pom.xml
@@ -64,6 +64,12 @@
       <artifactId>citrus-validation-json</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.citrusframework.yaks</groupId>
+      <artifactId>yaks-standard</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 </project>

--- a/java/steps/yaks-http/src/test/java/org/citrusframework/yaks/http/HttpFeatureTest.java
+++ b/java/steps/yaks-http/src/test/java/org/citrusframework/yaks/http/HttpFeatureTest.java
@@ -27,7 +27,7 @@ import org.junit.runner.RunWith;
 @RunWith(Cucumber.class)
 @CucumberOptions(
         strict = true,
-        extraGlue = { "com.consol.citrus.cucumber.step.runner.core" },
+        extraGlue = { "org.citrusframework.yaks.standard" },
         plugin = { "pretty", "com.consol.citrus.cucumber.CitrusReporter" }
 )
 public class HttpFeatureTest {

--- a/java/steps/yaks-jdbc/pom.xml
+++ b/java/steps/yaks-jdbc/pom.xml
@@ -77,6 +77,12 @@
       <artifactId>postgresql</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.citrusframework.yaks</groupId>
+      <artifactId>yaks-standard</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 </project>

--- a/java/steps/yaks-jdbc/src/test/java/org/citrusframework/yaks/jdbc/JdbcStepsTest.java
+++ b/java/steps/yaks-jdbc/src/test/java/org/citrusframework/yaks/jdbc/JdbcStepsTest.java
@@ -32,7 +32,7 @@ import org.testcontainers.containers.PostgreSQLContainer;
 @RunWith(Cucumber.class)
 @CucumberOptions(
         strict = true,
-        extraGlue = { "com.consol.citrus.cucumber.step.runner.core" },
+        extraGlue = { "org.citrusframework.yaks.standard" },
         plugin = { "pretty", "com.consol.citrus.cucumber.CitrusReporter" }
 )
 public class JdbcStepsTest {

--- a/java/steps/yaks-jms/pom.xml
+++ b/java/steps/yaks-jms/pom.xml
@@ -124,6 +124,12 @@
       <artifactId>citrus-validation-text</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.citrusframework.yaks</groupId>
+      <artifactId>yaks-standard</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 </project>

--- a/java/steps/yaks-jms/src/test/java/org/citrusframework/yaks/jms/JmsFeatureTest.java
+++ b/java/steps/yaks-jms/src/test/java/org/citrusframework/yaks/jms/JmsFeatureTest.java
@@ -24,7 +24,7 @@ import org.junit.runner.RunWith;
 @RunWith(Cucumber.class)
 @CucumberOptions(
         strict = true,
-        extraGlue = { "com.consol.citrus.cucumber.step.runner.core" },
+        extraGlue = { "org.citrusframework.yaks.standard" },
         plugin = { "pretty", "com.consol.citrus.cucumber.CitrusReporter" }
 )
 public class JmsFeatureTest {

--- a/java/steps/yaks-kafka/pom.xml
+++ b/java/steps/yaks-kafka/pom.xml
@@ -69,6 +69,12 @@
       <artifactId>citrus-validation-text</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.citrusframework.yaks</groupId>
+      <artifactId>yaks-standard</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 </project>

--- a/java/steps/yaks-kafka/src/test/java/org/citrusframework/yaks/kafka/KafkaFeatureTest.java
+++ b/java/steps/yaks-kafka/src/test/java/org/citrusframework/yaks/kafka/KafkaFeatureTest.java
@@ -24,7 +24,7 @@ import org.junit.runner.RunWith;
 @RunWith(Cucumber.class)
 @CucumberOptions(
         strict = true,
-        extraGlue = { "com.consol.citrus.cucumber.step.runner.core" },
+        extraGlue = { "org.citrusframework.yaks.standard" },
         plugin = { "pretty", "com.consol.citrus.cucumber.CitrusReporter" }
 )
 public class KafkaFeatureTest {

--- a/java/steps/yaks-knative/src/test/java/org/citrusframework/yaks/knative/KnativeFeatureTest.java
+++ b/java/steps/yaks-knative/src/test/java/org/citrusframework/yaks/knative/KnativeFeatureTest.java
@@ -27,7 +27,7 @@ import org.junit.runner.RunWith;
 @RunWith(Cucumber.class)
 @CucumberOptions(
         strict = true,
-        extraGlue = { "com.consol.citrus.cucumber.step.runner.core" },
+        extraGlue = { "org.citrusframework.yaks.standard" },
         plugin = { "pretty", "com.consol.citrus.cucumber.CitrusReporter" }
 )
 public class KnativeFeatureTest {

--- a/java/steps/yaks-openapi/pom.xml
+++ b/java/steps/yaks-openapi/pom.xml
@@ -76,6 +76,12 @@
       <artifactId>citrus-validation-hamcrest</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.citrusframework.yaks</groupId>
+      <artifactId>yaks-standard</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 </project>

--- a/java/steps/yaks-openapi/src/test/java/org/citrusframework/yaks/openapi/OpenApiFeatureTest.java
+++ b/java/steps/yaks-openapi/src/test/java/org/citrusframework/yaks/openapi/OpenApiFeatureTest.java
@@ -28,7 +28,7 @@ import org.junit.runner.RunWith;
 @CucumberOptions(
         strict = true,
         extraGlue = {
-                "com.consol.citrus.cucumber.step.runner.core",
+                "org.citrusframework.yaks.standard",
                 "org.citrusframework.yaks.http"
         },
         plugin = { "pretty", "com.consol.citrus.cucumber.CitrusReporter" }

--- a/java/steps/yaks-standard/pom.xml
+++ b/java/steps/yaks-standard/pom.xml
@@ -63,6 +63,21 @@
       <artifactId>citrus-core-spring</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.consol.citrus</groupId>
+      <artifactId>citrus-camel</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.consol.citrus</groupId>
+      <artifactId>citrus-validation-json</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.consol.citrus</groupId>
+      <artifactId>citrus-validation-text</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 </project>

--- a/java/steps/yaks-standard/src/main/java/org/citrusframework/yaks/standard/ComponentSteps.java
+++ b/java/steps/yaks-standard/src/main/java/org/citrusframework/yaks/standard/ComponentSteps.java
@@ -17,35 +17,21 @@
 
 package org.citrusframework.yaks.standard;
 
-import com.consol.citrus.TestCaseRunner;
-import com.consol.citrus.annotations.CitrusResource;
+import com.consol.citrus.Citrus;
+import com.consol.citrus.annotations.CitrusFramework;
+import com.consol.citrus.message.DefaultMessageQueue;
 import io.cucumber.java.en.Given;
-import io.cucumber.java.en.Then;
 
-import static com.consol.citrus.actions.EchoAction.Builder.echo;
+/**
+ * @author Christoph Deppisch
+ */
+public class ComponentSteps {
 
-public class YaksStandardSteps {
+    @CitrusFramework
+    private Citrus citrus;
 
-    @CitrusResource
-    private TestCaseRunner runner;
-
-    @Given("^YAKS does Cloud-Native BDD testing$")
-    public void itDoesBDD() {
-        print("YAKS does Cloud-Native BDD testing");
-    }
-
-    @Then("^YAKS rocks!$")
-    public void yaksRocks() {
-        print("YAKS rocks!");
-    }
-
-    @Then("^(?:log|print) '(.+)'$")
-    public void print(String message) {
-        runner.run(echo(message));
-    }
-
-    @Then("^(?:log|print)$")
-    public void printMultiline(String message) {
-        runner.run(echo(message));
+    @Given("^(?:create|new) message queue ([^\"\\s]+)$")
+    public void createMessageQueue(String name) {
+        citrus.getCitrusContext().getReferenceResolver().bind(name, new DefaultMessageQueue());
     }
 }

--- a/java/steps/yaks-standard/src/main/java/org/citrusframework/yaks/standard/MessagingSteps.java
+++ b/java/steps/yaks-standard/src/main/java/org/citrusframework/yaks/standard/MessagingSteps.java
@@ -1,0 +1,145 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.yaks.standard;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import com.consol.citrus.CitrusSettings;
+import com.consol.citrus.TestCaseRunner;
+import com.consol.citrus.annotations.CitrusResource;
+import com.consol.citrus.exceptions.CitrusRuntimeException;
+import com.consol.citrus.message.DefaultMessage;
+import com.consol.citrus.message.Message;
+import io.cucumber.java.Before;
+import io.cucumber.java.en.And;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
+
+import static com.consol.citrus.actions.ReceiveMessageAction.Builder.receive;
+import static com.consol.citrus.actions.SendMessageAction.Builder.send;
+
+/**
+ * @author Christoph Deppisch
+ */
+public class MessagingSteps {
+
+    @CitrusResource
+    private TestCaseRunner runner;
+
+    /** Messages defined by id */
+    private Map<String, Message> messages;
+
+    @Before
+    public void before() {
+        messages = new HashMap<>();
+    }
+
+    @Given("^(?:create|new) message ([^\\s]+)$")
+    public void message(String messageId) {
+        messages.put(messageId, new DefaultMessage());
+    }
+
+    @When("^endpoint ([^\\s]+) sends message \\$([^\\s]+)$")
+    @Then("^endpoint ([^\\s]+) should send message \\$([^\\s]+)$")
+    public void sendMessage(final String endpoint, final String messageId) {
+        if (messages.containsKey(messageId)) {
+            runner.when(send()
+                    .endpoint(endpoint)
+                    .message(new DefaultMessage(messages.get(messageId))));
+        } else {
+            throw new CitrusRuntimeException(String.format("Unable to find message for id '%s'", messageId));
+        }
+    }
+
+    @When("^endpoint ([^\\s]+) sends payload ([\\w\\W]+)$")
+    @Then("^endpoint ([^\\s]+) should send payload ([\\w\\W]+)$")
+    public void sendPayload(final String endpoint, final String payload) {
+        runner.when(send()
+                .endpoint(endpoint)
+                .payload(payload));
+    }
+
+    @When("^endpoint ([^\\s]+) sends payload$")
+    @Then("^endpoint ([^\\s]+) should send payload$")
+    public void sendMultilinePayload(String endpoint, String payload) {
+        sendPayload(endpoint, payload);
+    }
+
+    @When("^endpoint ([^\\s]+) receives ([^\\s]+) message \\$([^\\s]+)$")
+    @Then("^endpoint ([^\\s]+) should receive ([^\\s]+) message \\$([^\\s]+)$")
+    public void receiveMessage(final String endpoint, final String type, final String messageId) {
+        if (messages.containsKey(messageId)) {
+            runner.when(receive()
+                    .endpoint(endpoint)
+                    .messageType(type)
+                    .message(new DefaultMessage(messages.get(messageId))));
+        } else {
+            throw new CitrusRuntimeException(String.format("Unable to find message for id '%s'", messageId));
+        }
+    }
+
+    @When("^endpoint ([^\\s]+) receives message \\$([^\\s]+)$")
+    @Then("^endpoint ([^\\s]+) should receive message \\$([^\\s]+)$")
+    public void receiveMessage(final String endpoint, final String messageName) {
+        receiveMessage(endpoint, CitrusSettings.DEFAULT_MESSAGE_TYPE, messageName);
+    }
+
+    @When("^endpoint ([^\\s]+) receives ([^\\s]+) payload ([\\w\\W]+)$")
+    @Then("^endpoint ([^\\s]+) should receive ([^\\s]+) payload ([\\w\\W]+)$")
+    public void receivePayload(final String endpoint, final String type, final String payload) {
+        runner.when(receive()
+                .endpoint(endpoint)
+                .messageType(type)
+                .payload(payload));
+    }
+
+    @When("^endpoint ([^\\s]+) receives payload ([\\w\\W]+)$")
+    @Then("^endpoint ([^\\s]+) should receive payload ([\\w\\W]+)$")
+    public void receiveDefault(String endpoint, String payload) {
+        receivePayload(endpoint, CitrusSettings.DEFAULT_MESSAGE_TYPE, payload);
+    }
+
+    @When("^endpoint ([^\\s]+) receives payload$")
+    @Then("^endpoint ([^\\s]+) should receive payload$")
+    public void receiveMultilinePayload(String endpoint, String payload) {
+        receivePayload(endpoint, CitrusSettings.DEFAULT_MESSAGE_TYPE, payload);
+    }
+
+    @When("^endpoint ([^\\s]+) receives ([^\\s]+) payload$")
+    @Then("^endpoint ([^\\s]+) should receive ([^\\s]+) payload$")
+    public void shouldReceiveMultiline(String endpoint, String type, String payload) {
+        receivePayload(endpoint, type, payload);
+    }
+
+    @And("^\\$([^\\s]+) header ([^\\s]+)(?: is |=)\"([^\"]*)\"$")
+    public void addHeader(String messageId, String name, String value) {
+        messages.get(messageId).setHeader(name, value);
+    }
+
+    @And("^\\$([^\\s]+) has payload ([\\w\\W]+)$")
+    public void addPayload(String messageId, String payload) {
+        messages.get(messageId).setPayload(payload);
+    }
+
+    @And("^\\$([^\\s]+) has payload$")
+    public void addPayloadMultiline(String messageId, String payload) {
+        addPayload(messageId, payload);
+    }
+}

--- a/java/steps/yaks-standard/src/main/java/org/citrusframework/yaks/standard/StandardSteps.java
+++ b/java/steps/yaks-standard/src/main/java/org/citrusframework/yaks/standard/StandardSteps.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.yaks.standard;
+
+import java.util.Map;
+
+import com.consol.citrus.TestCaseRunner;
+import com.consol.citrus.annotations.CitrusResource;
+import io.cucumber.datatable.DataTable;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
+
+import static com.consol.citrus.actions.EchoAction.Builder.echo;
+import static com.consol.citrus.actions.SleepAction.Builder.sleep;
+
+public class StandardSteps {
+
+    @CitrusResource
+    private TestCaseRunner runner;
+
+    @Given("^YAKS does Cloud-Native BDD testing$")
+    public void itDoesBDD() {
+        print("YAKS does Cloud-Native BDD testing");
+    }
+
+    @Then("^YAKS rocks!$")
+    public void yaksRocks() {
+        print("YAKS rocks!");
+    }
+
+    @Given("^variable ([^\\s]+) is \"([^\"]*)\"$")
+    public void variable(String name, String value) {
+        runner.variable(name, value);
+    }
+
+    @Given("^variables$")
+    public void variables(DataTable dataTable) {
+        Map<String, String> variables = dataTable.asMap(String.class, String.class);
+        for (Map.Entry<String, String> entry : variables.entrySet()) {
+            runner.variable(entry.getKey(), entry.getValue());
+        }
+    }
+
+    @Then("^(?:log|print) '(.+)'$")
+    public void print(String message) {
+        runner.run(echo(message));
+    }
+
+    @Then("^(?:log|print)$")
+    public void printMultiline(String message) {
+        runner.run(echo(message));
+    }
+
+    @Then("^sleep$")
+    public void doSleep() {
+        runner.then(sleep());
+    }
+
+    @Then("^sleep (\\d+) ms$")
+    public void doSleep(long milliseconds) {
+        runner.then(sleep().milliseconds(milliseconds));
+    }
+}

--- a/java/steps/yaks-standard/src/test/java/org/citrusframework/yaks/report/ReporterTest.java
+++ b/java/steps/yaks-standard/src/test/java/org/citrusframework/yaks/report/ReporterTest.java
@@ -29,8 +29,7 @@ import org.junit.runner.RunWith;
         strict = true,
         extraGlue = {
                 "org.citrusframework.yaks.standard",
-                "org.citrusframework.yaks.hooks",
-                "com.consol.citrus.cucumber.step.runner.core"
+                "org.citrusframework.yaks.hooks"
         },
         plugin = {
                 "pretty",

--- a/java/steps/yaks-standard/src/test/java/org/citrusframework/yaks/standard/EndpointConfiguration.java
+++ b/java/steps/yaks-standard/src/test/java/org/citrusframework/yaks/standard/EndpointConfiguration.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.yaks.standard;
+
+import com.consol.citrus.camel.endpoint.CamelSyncEndpoint;
+import com.consol.citrus.camel.endpoint.CamelSyncEndpointConfiguration;
+import com.consol.citrus.endpoint.direct.DirectEndpoint;
+import com.consol.citrus.endpoint.direct.DirectEndpoints;
+import org.apache.camel.CamelContext;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.spring.SpringCamelContext;
+import org.springframework.beans.factory.BeanCreationException;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.DependsOn;
+
+/**
+ * @author Christoph Deppisch
+ */
+@Configuration
+public class EndpointConfiguration {
+
+    private CamelContext camelContext = new SpringCamelContext();
+
+    @Bean
+    public DirectEndpoint fooEndpoint() {
+        return DirectEndpoints
+                          .direct()
+                          .asynchronous()
+                          .queue("foo")
+                          .build();
+    }
+
+    @Bean
+    @DependsOn("camelContext")
+    public CamelSyncEndpoint echoEndpoint() {
+        CamelSyncEndpointConfiguration endpointConfiguration = new CamelSyncEndpointConfiguration();
+        endpointConfiguration.setCamelContext(camelContext);
+        endpointConfiguration.setEndpointUri("direct:echo");
+        return new CamelSyncEndpoint(endpointConfiguration);
+    }
+
+    @Bean
+    public CamelContext camelContext() {
+        RouteBuilder routeBuilder = new RouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+                from("direct:echo")
+                    .transform()
+                    .simple("You just said: ${body}");
+            }
+        };
+
+        try {
+            camelContext.addRoutes(routeBuilder);
+        } catch (Exception e) {
+            throw new BeanCreationException("Failed to create Camel context", e);
+        }
+        return camelContext;
+    }
+}

--- a/java/steps/yaks-standard/src/test/resources/citrus-application.properties
+++ b/java/steps/yaks-standard/src/test/resources/citrus-application.properties
@@ -1,0 +1,19 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+citrus.spring.java.config=org.citrusframework.yaks.standard.EndpointConfiguration
+citrus.default.message.type=JSON

--- a/java/steps/yaks-standard/src/test/resources/org/citrusframework/yaks/report/report.feature
+++ b/java/steps/yaks-standard/src/test/resources/org/citrusframework/yaks/report/report.feature
@@ -1,4 +1,4 @@
 Feature: Test reporter
 
   Scenario: Success test
-    Given echo "YAKS rocks!"
+    Given log 'YAKS rocks!'

--- a/java/steps/yaks-standard/src/test/resources/org/citrusframework/yaks/standard/helloworld.feature
+++ b/java/steps/yaks-standard/src/test/resources/org/citrusframework/yaks/standard/helloworld.feature
@@ -1,4 +1,4 @@
-Feature: hello world
+Feature: Hello world
 
   Scenario: print slogan
     Given YAKS does Cloud-Native BDD testing

--- a/java/steps/yaks-standard/src/test/resources/org/citrusframework/yaks/standard/messaging.feature
+++ b/java/steps/yaks-standard/src/test/resources/org/citrusframework/yaks/standard/messaging.feature
@@ -1,0 +1,69 @@
+Feature: Messaging features
+
+Background:
+  Given variable text is "Hello from citrus:randomString(10)"
+  Given create message queue foo
+
+  Scenario: Send and receive inline
+    When endpoint fooEndpoint sends payload {"message": {"text": "${text}"}}
+    Then endpoint fooEndpoint should receive payload {"message": {"text": "${text}"}}
+    Then endpoint fooEndpoint should send payload {"message": {"text": "${text}"}}
+     And endpoint fooEndpoint receives payload {"message": {"text": "${text}"}}
+
+  Scenario: Send and receive multiline
+    When endpoint fooEndpoint sends payload
+      """
+      {
+        "message": {
+          "text": "${text}"
+        }
+      }
+      """
+    Then endpoint fooEndpoint should receive payload
+      """
+      {
+        "message": {
+          "text": "${text}"
+        }
+      }
+      """
+
+  Scenario: Send and receive plaintext inline
+    When endpoint echoEndpoint sends payload ${text}
+    Then endpoint echoEndpoint should receive plaintext payload You just said: ${text}
+
+  Scenario: Send and receive plaintext multiline
+    When endpoint echoEndpoint sends payload
+      """
+      ${text}
+      """
+    Then endpoint echoEndpoint should receive plaintext payload
+      """
+      You just said: ${text}
+      """
+
+  Scenario: Message definition inline
+    Given new message echoRequest
+      And $echoRequest has payload ${text}
+      And $echoRequest header operation is "sayHello"
+    Given new message echoResponse
+      And $echoResponse has payload You just said: ${text}
+      And $echoResponse header operation is "sayHello"
+    When endpoint echoEndpoint sends message $echoRequest
+    Then endpoint echoEndpoint should receive plaintext message $echoResponse
+
+  Scenario: Message definition multiline
+    Given new message echoRequest
+      And $echoRequest has payload
+        """
+        ${text}
+        """
+      And $echoRequest header operation="sayHello"
+    Given new message echoResponse
+      And $echoResponse has payload
+        """
+        You just said: ${text}
+        """
+      And $echoResponse header operation="sayHello"
+    When endpoint echoEndpoint sends message $echoRequest
+    Then endpoint echoEndpoint should receive plaintext message $echoResponse


### PR DESCRIPTION
Use own standard messaging steps to align with other steps provided in YAKS.