### PR TITLE
Increase test timeout

### DIFF
--- a/pkg/cmd/test.go
+++ b/pkg/cmd/test.go
@@ -403,7 +403,7 @@ func (o *testCmdOptions) createAndRunTest(c client.Client, rawName string, runCo
 				}
 			}
 			return false, nil
-		}, 10*time.Minute)
+		}, 30*time.Minute)
 
 		cancel()
 	}()


### PR DESCRIPTION
10 minutes timeout to pass the test could not be enough.