### PR TITLE
fix(#134): Make scripts portable

### DIFF
--- a/script/next_snapshot.sh
+++ b/script/next_snapshot.sh
@@ -44,6 +44,11 @@ do
     fi
   done
   if [ "$check" = true ]; then
-    sed -i '' "$version_rule" $f
+    if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+      sed -i "$version_rule" $f
+    elif [[ "$OSTYPE" == "darwin"* ]]; then
+      # Mac OSX
+      sed -i '' "$version_rule" $f
+    fi
   fi
 done

--- a/script/set_modules_version.sh
+++ b/script/set_modules_version.sh
@@ -28,4 +28,9 @@ target_tag=v$target_version
 
 api_rule="s/github.com\/citrusframework\/yaks\/pkg\/apis\/yaks [A-Za-z0-9\.\-]+.*$/github.com\/citrusframework\/yaks\/pkg\/apis\/yaks $target_tag/"
 
-sed -i '' -E "$api_rule" $location/../go.mod
+if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+  sed -i -r "$api_rule" $location/../go.mod
+elif [[ "$OSTYPE" == "darwin"* ]]; then
+  # Mac OSX
+  sed -i '' -E "$api_rule" $location/../go.mod
+fi

--- a/script/set_version.sh
+++ b/script/set_version.sh
@@ -29,7 +29,12 @@ sanitized_image_name=${image_name//\//\\\/}
 
 for f in $(find $location/../deploy -type f -name "*.yaml" | grep -v olm-catalog);
 do
+  if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+    sed -i -r "s/docker.io\/citrusframework\/yaks:([0-9]+[a-zA-Z0-9\-\.].*).*/${sanitized_image_name}:${version}/" $f
+  elif [[ "$OSTYPE" == "darwin"* ]]; then
+    # Mac OSX
     sed -i '' -E "s/docker.io\/citrusframework\/yaks:([0-9]+[a-zA-Z0-9\-\.].*).*/${sanitized_image_name}:${version}/" $f
+  fi
 done
 
 echo "YAKS version set to: $version and image name to: $sanitized_image_name:$version"

--- a/script/unsnapshot_olm.sh
+++ b/script/unsnapshot_olm.sh
@@ -40,9 +40,19 @@ done
 
 for f in $(find ${olm_catalog}/yaks -type f);
 do
-  sed -i '' 's/-SNAPSHOT//g' $f
+  if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+    sed -i 's/-SNAPSHOT//g' $f
+  elif [[ "$OSTYPE" == "darwin"* ]]; then
+    # Mac OSX
+    sed -i '' 's/-SNAPSHOT//g' $f
+  fi
 done
 for f in $(find ${olm_catalog}/yaks -type f);
 do
-  sed -i '' 's/-snapshot//g' $f
+  if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+    sed -i 's/-snapshot//g' $f
+  elif [[ "$OSTYPE" == "darwin"* ]]; then
+    # Mac OSX
+    sed -i '' 's/-snapshot//g' $f
+  fi
 done

--- a/script/unsnapshot_sources.sh
+++ b/script/unsnapshot_sources.sh
@@ -30,6 +30,11 @@ do
     fi
   done
   if [ "$check" = true ]; then
-    sed -i '' 's/-SNAPSHOT//g' $f
+    if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+      sed -i 's/-SNAPSHOT//g' $f
+    elif [[ "$OSTYPE" == "darwin"* ]]; then
+      # Mac OSX
+      sed -i '' 's/-SNAPSHOT//g' $f
+    fi
   fi
 done


### PR DESCRIPTION
Different OS types for CI and local development require portable scripts.