### PR TITLE
fix(#141): Set Kafka producer/consumer properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
-![build](https://github.com/citrusframework/yaks/workflows/build/badge.svg?branch=master)
-
 # YAKS ![logo][1] 
 
-YAKS is Cloud Native BDD testing or simply: Yet Another Kubernetes Service!
+[![build](https://github.com/citrusframework/yaks/workflows/build/badge.svg?branch=master)](https://github.com/citrusframework/yaks/actions) 
+[![Licensed under Apache License version 2.0](https://img.shields.io/github/license/openshift/origin.svg?maxAge=2592000)](https://www.apache.org/licenses/LICENSE-2.0")
+[![Chat on Zulip](https://img.shields.io/badge/zulip-join_chat-brightgreen.svg)](https://citrusframework.zulipchat.com)
+
+YAKS is a platform to enable Cloud Native BDD testing on Kubernetes!
 
 * [Getting started](#getting-started)
   * [Installation](#installation)
@@ -27,8 +29,13 @@ YAKS is Cloud Native BDD testing or simply: Yet Another Kubernetes Service!
 
 ## Getting Started
 
-YAKS allows you to perform Could Native BDD testing. Cloud Native here means that your tests execute within a POD in a 
-Kubernetes cluster. All you need to do is to write some BDD feature specs using the [Gherkin syntax from Cucumber](https://cucumber.io/docs/gherkin/).
+YAKS allows you to perform Could Native BDD testing. Cloud Native here means that your tests executes within a Kubernetes POD. 
+
+With the YAKS operator installed, you can run tests by creating a `Test` custom resource on the cluster.
+
+Tests are defined using [Gherkin](https://cucumber.io/docs/gherkin/) syntax. As a framework YAKS provides a set of predefined steps which
+help to connect with different messaging transports (Http REST, JMS, Kafka, Knative eventing) and verify responses with
+assertions on message header and body content.
 
 ### Windows prerequisite
 For full support of Yaks on Windows please enable "Windows Subsystem for Linux". You can do it manually by heading to Control Panel > Programs > Turn 

--- a/java/steps/yaks-http/src/main/java/org/citrusframework/yaks/http/HttpClientSteps.java
+++ b/java/steps/yaks-http/src/main/java/org/citrusframework/yaks/http/HttpClientSteps.java
@@ -90,10 +90,12 @@ public class HttpClientSteps implements HttpSteps {
 
     @Before
     public void before(Scenario scenario) {
-        if (httpClient == null && citrus.getCitrusContext().getReferenceResolver().resolveAll(HttpClient.class).size() == 1L) {
-            httpClient = citrus.getCitrusContext().getReferenceResolver().resolve(HttpClient.class);
-        } else {
-            httpClient = new HttpClientBuilder().build();
+        if (httpClient == null) {
+            if (citrus.getCitrusContext().getReferenceResolver().resolveAll(HttpClient.class).size() == 1L) {
+                httpClient = citrus.getCitrusContext().getReferenceResolver().resolve(HttpClient.class);
+            } else {
+                httpClient = new HttpClientBuilder().build();
+            }
         }
 
         timeout = httpClient.getEndpointConfiguration().getTimeout();

--- a/java/steps/yaks-http/src/main/java/org/citrusframework/yaks/http/HttpServerSteps.java
+++ b/java/steps/yaks-http/src/main/java/org/citrusframework/yaks/http/HttpServerSteps.java
@@ -71,19 +71,23 @@ public class HttpServerSteps implements HttpSteps {
 
     @Before
     public void before(Scenario scenario) {
-        if (httpServer == null && citrus.getCitrusContext().getReferenceResolver().resolveAll(HttpServer.class).size() == 1L) {
-            httpServer = citrus.getCitrusContext().getReferenceResolver().resolve(HttpServer.class);
-        } else {
-            httpServer = new HttpServerBuilder()
-                    .name(HTTP_SERVER_NAME)
-                    .build();
+        if (httpServer == null) {
+            if (citrus.getCitrusContext().getReferenceResolver().resolveAll(HttpServer.class).size() == 1L) {
+                httpServer = citrus.getCitrusContext().getReferenceResolver().resolve(HttpServer.class);
+            } else if (citrus.getCitrusContext().getReferenceResolver().isResolvable(HTTP_SERVER_NAME)) {
+                httpServer = citrus.getCitrusContext().getReferenceResolver().resolve(HTTP_SERVER_NAME, HttpServer.class);
+            } else {
+                httpServer = new HttpServerBuilder()
+                        .name(HTTP_SERVER_NAME)
+                        .build();
 
-            citrus.getCitrusContext().getReferenceResolver().bind(HTTP_SERVER_NAME, httpServer);
+                citrus.getCitrusContext().getReferenceResolver().bind(HTTP_SERVER_NAME, httpServer);
 
-            try {
-                httpServer.afterPropertiesSet();
-            } catch (Exception e) {
-                throw new IllegalStateException("Failed to initialize Http server", e);
+                try {
+                    httpServer.afterPropertiesSet();
+                } catch (Exception e) {
+                    throw new IllegalStateException("Failed to initialize Http server", e);
+                }
             }
         }
 

--- a/java/steps/yaks-kafka/src/main/java/org/citrusframework/yaks/kafka/KafkaSettings.java
+++ b/java/steps/yaks-kafka/src/main/java/org/citrusframework/yaks/kafka/KafkaSettings.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.yaks.kafka;
+
+/**
+ * @author Christoph Deppisch
+ */
+public class KafkaSettings {
+
+    private static final String KNATIVE_PROPERTY_PREFIX = "yaks.kafka.";
+    private static final String KNATIVE_ENV_PREFIX = "YAKS_KAFKA_";
+
+    private static final String CONSUMER_TIMEOUT_PROPERTY = KNATIVE_PROPERTY_PREFIX + "timeout";
+    private static final String CONSUMER_TIMEOUT_ENV = KNATIVE_ENV_PREFIX + "TIMEOUT";
+    private static final String CONSUMER_TIMEOUT_DEFAULT = "60000";
+
+    private KafkaSettings() {
+        // prevent instantiation of utility class
+    }
+
+    /**
+     * Timeout when receiving messages.
+     * @return time in milliseconds
+     */
+    public static long getConsumerTimeout() {
+        return Long.parseLong(System.getProperty(CONSUMER_TIMEOUT_PROPERTY,
+                System.getenv(CONSUMER_TIMEOUT_ENV) != null ? System.getenv(CONSUMER_TIMEOUT_ENV) : CONSUMER_TIMEOUT_DEFAULT));
+    }
+}

--- a/java/steps/yaks-kafka/src/test/resources/org/citrusframework/yaks/kafka/kafka-multiline.feature
+++ b/java/steps/yaks-kafka/src/test/resources/org/citrusframework/yaks/kafka/kafka-multiline.feature
@@ -1,22 +1,35 @@
-Feature: Kafka steps
+Feature: Kafka multiline steps
 
   Background:
+    Given Kafka consumer timeout is 5000 milliseconds
     Given Kafka connection
         | url           | localhost:9092 |
-        | topic         | hello |
-        | consumerGroup | hello-group |
+        | topic         | hello          |
+        | consumerGroup | hello-group    |
 
-  Scenario: Send and receive multiline body
-    When send message to Kafka with body
+  Scenario: Predefined multiline body
+    Given Kafka message body
       """
       {
         "message": "Hello from YAKS!"
       }
       """
-    Then expect message in Kafka with body
+    When send Kafka message to topic hello
+    Then verify Kafka message body
+      """
+      { "message": "Hello from YAKS!" }
+      """
+    And receive Kafka message on topic hello
+
+  Scenario: Multiline body
+    When send Kafka message with body
       """
       {
         "message": "Hello from YAKS!"
       }
+      """
+    Then expect Kafka message with body
+      """
+      { "message": "Hello from YAKS!" }
       """
 

--- a/java/steps/yaks-kafka/src/test/resources/org/citrusframework/yaks/kafka/kafka.feature
+++ b/java/steps/yaks-kafka/src/test/resources/org/citrusframework/yaks/kafka/kafka.feature
@@ -1,15 +1,26 @@
 Feature: Kafka steps
 
   Background:
-    Given Kafka connection
-        | url       | localhost:9092 |
-        | topic     | test |
-
-  Scenario: Send and receive body and headers
     Given variable body is "citrus:randomString(10)"
     Given variable key is "citrus:randomString(10)"
     Given variable value is "citrus:randomString(10)"
-    When send message to Kafka with body and headers: ${body}
+    Given Kafka consumer timeout is 5000 milliseconds
+    Given Kafka topic: hello
+    Given Kafka connection
+      | url         | localhost:9092 |
+
+  Scenario: Send and receive with predefined body and headers
+    Given Kafka message body: ${body}
+    And Kafka message header ${key}="${value}"
+    And Kafka message key: 1
+    When send Kafka message
+    Then verify Kafka message body: ${body}
+    And verify Kafka message header ${key} is "${value}"
+    And receive Kafka message
+
+  Scenario: Send and receive body and headers
+    And Kafka message key: 2
+    When send Kafka message with body and headers: ${body}
       | ${key} | ${value} |
-    Then expect message in Kafka with body and headers: ${body}
+    Then expect Kafka message with body and headers: ${body}
       | ${key} | ${value} |

--- a/java/steps/yaks-knative/src/main/java/org/citrusframework/yaks/knative/SendEventSteps.java
+++ b/java/steps/yaks-knative/src/main/java/org/citrusframework/yaks/knative/SendEventSteps.java
@@ -69,13 +69,15 @@ public class SendEventSteps {
 
     @Before
     public void before(Scenario scenario) {
-        if (httpClient == null && citrus.getCitrusContext().getReferenceResolver().resolveAll(HttpClient.class).size() == 1L) {
-            httpClient = citrus.getCitrusContext().getReferenceResolver().resolve(HttpClient.class);
-            timeout = httpClient.getEndpointConfiguration().getTimeout();
-        } else {
-            httpClient = new HttpClientBuilder()
-                    .timeout(timeout)
-                    .build();
+        if (httpClient == null) {
+            if (citrus.getCitrusContext().getReferenceResolver().resolveAll(HttpClient.class).size() == 1L) {
+                httpClient = citrus.getCitrusContext().getReferenceResolver().resolve(HttpClient.class);
+                timeout = httpClient.getEndpointConfiguration().getTimeout();
+            } else {
+                httpClient = new HttpClientBuilder()
+                        .timeout(timeout)
+                        .build();
+            }
         }
 
         eventData = null;


### PR DESCRIPTION
Fixes #141 

- Add step to set producer/consumer properties
- Add step to set the message key
- Add step to set the Kafka topic
- Align steps with other modules saying "send/receive Kafka message"
- Reuse Kafka endpoint from Citrus context (keep consumer offset and enable multiple scenarios to receive messages from a topic)
- Add steps to explicitly set message body and headers (to align with other YAKS modules)