### PR TITLE
fix(#139): Reduce boilerplate logs

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM fabric8/s2i-java:3.0-java8
+FROM fabric8/s2i-java:3.1.0-java8
 
 ENV OPERATOR=/usr/local/bin/yaks \
     OPERATOR_ARGS=operator \

--- a/examples/logging/logging.feature
+++ b/examples/logging/logging.feature
@@ -1,0 +1,8 @@
+Feature: Show logging levels
+
+  Scenario: Print YAKS slogan
+    Given YAKS does Cloud-Native BDD testing
+    Then YAKS rocks!
+
+  Scenario: Print message
+    Given print 'Hello from YAKS!'

--- a/examples/logging/yaks-config.yaml
+++ b/examples/logging/yaks-config.yaml
@@ -1,6 +1,6 @@
-#
+# ---------------------------------------------------------------------------
 # Licensed to the Apache Software Foundation (ASF) under one or more
-# contributor license agreements. See the NOTICE file distributed with
+# contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.
 # The ASF licenses this file to You under the Apache License, Version 2.0
 # (the "License"); you may not use this file except in compliance with
@@ -13,16 +13,19 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
+# ---------------------------------------------------------------------------
 
-# Maven repositories
-yaks.repository.central=https://repo.maven.apache.org/maven2/
-yaks.repository.jboss-ea=https://repository.jboss.org/nexus/content/groups/ea/
-
-# Include these dependencies additional dependencies
-yaks.dependency.foo=org.foo:foo-artifact:1.0.0
-yaks.dependency.bar=org.bar:bar-artifact:1.5.0
-
-logging.level.root=INFO
-logging.level.org.foo=DEBUG
-logging.level.org.bar=WARN
+config:
+  runtime:
+    settings:
+      loggers:
+        - name: root
+          level: INFO
+        - name: org.citrusframework.yaks
+          level: DEBUG
+        - name: com.consol.citrus
+          level: INFO
+        - name: Logger.Message_IN
+          level: DEBUG
+        - name: Logger.Message_OUT
+          level: DEBUG

--- a/examples/logging/yaks.properties
+++ b/examples/logging/yaks.properties
@@ -14,15 +14,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
-# Maven repositories
-yaks.repository.central=https://repo.maven.apache.org/maven2/
-yaks.repository.jboss-ea=https://repository.jboss.org/nexus/content/groups/ea/
-
-# Include these dependencies additional dependencies
-yaks.dependency.foo=org.foo:foo-artifact:1.0.0
-yaks.dependency.bar=org.bar:bar-artifact:1.5.0
-
-logging.level.root=INFO
-logging.level.org.foo=DEBUG
-logging.level.org.bar=WARN
+logging.level.org.citrusframework.yaks=DEBUG
+logging.level.com.consol.citrus=DEBUG

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -207,13 +207,6 @@
         <version>${camel.version}</version>
       </dependency>
 
-      <!-- Logging -->
-      <dependency>
-        <groupId>org.slf4j</groupId>
-        <artifactId>slf4j-api</artifactId>
-        <version>${slf4j.version}</version>
-      </dependency>
-
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-core</artifactId>
@@ -237,13 +230,24 @@
         <version>${groovy.version}</version>
       </dependency>
 
-      <!-- Unit testing -->
+      <!-- Logging -->
+      <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-api</artifactId>
+        <version>${slf4j.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.logging.log4j</groupId>
+        <artifactId>log4j-core</artifactId>
+        <version>${log4j2.version}</version>
+      </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-slf4j-impl</artifactId>
         <version>${log4j2.version}</version>
-        <scope>test</scope>
       </dependency>
+
+      <!-- Unit testing -->
       <dependency>
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>

--- a/java/runtime/yaks-runtime-maven/pom.xml
+++ b/java/runtime/yaks-runtime-maven/pom.xml
@@ -91,6 +91,11 @@
     </dependency>
     <dependency>
       <groupId>org.citrusframework.yaks</groupId>
+      <artifactId>yaks-groovy</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.citrusframework.yaks</groupId>
       <artifactId>yaks-standard</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/java/runtime/yaks-runtime-maven/src/test/resources/log4j2-test.xml
+++ b/java/runtime/yaks-runtime-maven/src/test/resources/log4j2-test.xml
@@ -15,7 +15,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 -->
-<Configuration status="INFO">
+<Configuration status="ERROR">
   <Appenders>
     <Console name="STDOUT" target="SYSTEM_OUT">
       <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss.SSS}|%-5level|%t|%c{1} - %msg%n"/>
@@ -23,38 +23,9 @@
   </Appenders>
 
   <Loggers>
-    <Root level="INFO">
+    <Root level="ERROR">
       <AppenderRef ref="STDOUT"/>
     </Root>
-
-    <!-- Our own classes-->
-    <Logger name="org.citrusframework.yaks" additivity="false" level="DEBUG">
-      <AppenderRef ref="STDOUT"/>
-    </Logger>
-
-    <Logger name="com.consol.citrus" additivity="false" level="DEBUG">
-      <AppenderRef ref="STDOUT"/>
-    </Logger>
-
-    <Logger name="Logger.Message_IN" additivity="false" level="DEBUG">
-      <AppenderRef ref="STDOUT"/>
-    </Logger>
-
-    <Logger name="Logger.Message_OUT" additivity="false" level="DEBUG">
-      <AppenderRef ref="STDOUT"/>
-    </Logger>
-
-    <Logger name="org.springframework" additivity="false" level="WARN">
-      <AppenderRef ref="STDOUT"/>
-    </Logger>
-
-    <Logger name="org.eclipse" additivity="false" level="WARN">
-      <AppenderRef ref="STDOUT"/>
-    </Logger>
-
-    <Logger name="org.apache" additivity="false" level="WARN">
-      <AppenderRef ref="STDOUT"/>
-    </Logger>
   </Loggers>
 
 </Configuration>

--- a/java/steps/yaks-camel/src/test/resources/log4j2-test.xml
+++ b/java/steps/yaks-camel/src/test/resources/log4j2-test.xml
@@ -29,7 +29,7 @@
     </Root>
 
     <!-- Our own classes-->
-    <Logger name="org.citrusframework.yaks" additivity="false" level="DEBUG">
+    <Logger name="org.citrusframework.yaks" additivity="false" level="INFO">
       <AppenderRef ref="STDOUT"/>
     </Logger>
 

--- a/java/steps/yaks-groovy/src/test/resources/log4j2-test.xml
+++ b/java/steps/yaks-groovy/src/test/resources/log4j2-test.xml
@@ -29,7 +29,7 @@
     </Root>
 
     <!-- Our own classes-->
-    <Logger name="org.citrusframework.yaks" additivity="false" level="DEBUG">
+    <Logger name="org.citrusframework.yaks" additivity="false" level="INFO">
       <AppenderRef ref="STDOUT"/>
     </Logger>
 

--- a/java/steps/yaks-http/src/test/resources/log4j2-test.xml
+++ b/java/steps/yaks-http/src/test/resources/log4j2-test.xml
@@ -29,7 +29,7 @@
     </Root>
 
     <!-- Our own classes-->
-    <Logger name="org.citrusframework.yaks" additivity="false" level="DEBUG">
+    <Logger name="org.citrusframework.yaks" additivity="false" level="INFO">
       <AppenderRef ref="STDOUT"/>
     </Logger>
 

--- a/java/steps/yaks-jdbc/src/test/resources/log4j2-test.xml
+++ b/java/steps/yaks-jdbc/src/test/resources/log4j2-test.xml
@@ -29,7 +29,7 @@
     </Root>
 
     <!-- Our own classes-->
-    <Logger name="org.citrusframework.yaks" additivity="false" level="DEBUG">
+    <Logger name="org.citrusframework.yaks" additivity="false" level="INFO">
       <AppenderRef ref="STDOUT"/>
     </Logger>
 

--- a/java/steps/yaks-jms/src/test/resources/log4j2-test.xml
+++ b/java/steps/yaks-jms/src/test/resources/log4j2-test.xml
@@ -29,7 +29,7 @@
     </Root>
 
     <!-- Our own classes-->
-    <Logger name="org.citrusframework.yaks" additivity="false" level="DEBUG">
+    <Logger name="org.citrusframework.yaks" additivity="false" level="INFO">
       <AppenderRef ref="STDOUT"/>
     </Logger>
 

--- a/java/steps/yaks-kafka/src/test/resources/log4j2-test.xml
+++ b/java/steps/yaks-kafka/src/test/resources/log4j2-test.xml
@@ -29,7 +29,7 @@
     </Root>
 
     <!-- Our own classes-->
-    <Logger name="org.citrusframework.yaks" additivity="false" level="DEBUG">
+    <Logger name="org.citrusframework.yaks" additivity="false" level="INFO">
       <AppenderRef ref="STDOUT"/>
     </Logger>
 

--- a/java/steps/yaks-knative/src/test/resources/log4j2-test.xml
+++ b/java/steps/yaks-knative/src/test/resources/log4j2-test.xml
@@ -29,7 +29,7 @@
     </Root>
 
     <!-- Our own classes-->
-    <Logger name="org.citrusframework.yaks" additivity="false" level="DEBUG">
+    <Logger name="org.citrusframework.yaks" additivity="false" level="INFO">
       <AppenderRef ref="STDOUT"/>
     </Logger>
 

--- a/java/steps/yaks-openapi/src/test/resources/log4j2-test.xml
+++ b/java/steps/yaks-openapi/src/test/resources/log4j2-test.xml
@@ -29,7 +29,7 @@
     </Root>
 
     <!-- Our own classes-->
-    <Logger name="org.citrusframework.yaks" additivity="false" level="DEBUG">
+    <Logger name="org.citrusframework.yaks" additivity="false" level="INFO">
       <AppenderRef ref="STDOUT"/>
     </Logger>
 

--- a/java/steps/yaks-standard/src/main/java/org/citrusframework/yaks/report/TestResult.java
+++ b/java/steps/yaks-standard/src/main/java/org/citrusframework/yaks/report/TestResult.java
@@ -79,4 +79,9 @@ class TestResult {
     public void setCause(Throwable cause) {
         this.cause = cause;
     }
+
+    @JsonIgnore
+    public Throwable getCause() {
+        return cause;
+    }
 }

--- a/java/steps/yaks-standard/src/test/resources/log4j2-test.xml
+++ b/java/steps/yaks-standard/src/test/resources/log4j2-test.xml
@@ -29,7 +29,7 @@
     </Root>
 
     <!-- Our own classes-->
-    <Logger name="org.citrusframework.yaks" additivity="false" level="DEBUG">
+    <Logger name="org.citrusframework.yaks" additivity="false" level="INFO">
       <AppenderRef ref="STDOUT"/>
     </Logger>
 

--- a/java/tools/maven/yaks-maven-extension/pom.xml
+++ b/java/tools/maven/yaks-maven-extension/pom.xml
@@ -105,6 +105,11 @@
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/java/tools/maven/yaks-maven-extension/src/main/java/org/citrusframework/yaks/maven/extension/ExtensionSettings.java
+++ b/java/tools/maven/yaks-maven-extension/src/main/java/org/citrusframework/yaks/maven/extension/ExtensionSettings.java
@@ -37,6 +37,10 @@ public final class ExtensionSettings {
     public static final String REPOSITORIES_SETTING_KEY = "yaks.repositories";
     public static final String REPOSITORIES_SETTING_ENV = "YAKS_REPOSITORIES";
 
+    public static final String LOGGERS_SETTING_KEY = "yaks.loggers";
+    public static final String LOGGERS_SETTING_ENV = "YAKS_LOGGERS";
+    public static final String LOGGING_LEVEL_PREFIX = "logging.level.";
+
     /**
      * Prevent instantiation of utility class.
      */

--- a/java/tools/maven/yaks-maven-extension/src/main/java/org/citrusframework/yaks/maven/extension/configuration/AbstractConfigFileLoggingConfigurationLoader.java
+++ b/java/tools/maven/yaks-maven-extension/src/main/java/org/citrusframework/yaks/maven/extension/configuration/AbstractConfigFileLoggingConfigurationLoader.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.yaks.maven.extension.configuration;
+
+import java.nio.file.Path;
+import java.util.Optional;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.config.builder.api.ConfigurationBuilder;
+import org.apache.logging.log4j.core.config.builder.impl.BuiltConfiguration;
+import org.apache.maven.lifecycle.LifecycleExecutionException;
+import org.codehaus.plexus.logging.Logger;
+
+/**
+ * @author Christoph Deppisch
+ */
+public abstract class AbstractConfigFileLoggingConfigurationLoader implements LoggingConfigurationLoader  {
+
+    @Override
+    public Optional<Level> load(ConfigurationBuilder<BuiltConfiguration> builder, Logger logger) {
+        return Optional.empty();
+    }
+
+    /**
+     * Load logger configuration from given file.
+     * @param filePath
+     * @param builder
+     * @param logger
+     * @return root logger level if any is set
+     * @throws LifecycleExecutionException
+     */
+    protected abstract Optional<Level> load(Path filePath, ConfigurationBuilder<BuiltConfiguration> builder, Logger logger) throws LifecycleExecutionException;
+}

--- a/java/tools/maven/yaks-maven-extension/src/main/java/org/citrusframework/yaks/maven/extension/configuration/FileBasedLoggingConfigurationLoader.java
+++ b/java/tools/maven/yaks-maven-extension/src/main/java/org/citrusframework/yaks/maven/extension/configuration/FileBasedLoggingConfigurationLoader.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.yaks.maven.extension.configuration;
+
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.config.builder.api.ConfigurationBuilder;
+import org.apache.logging.log4j.core.config.builder.impl.BuiltConfiguration;
+import org.apache.maven.lifecycle.LifecycleExecutionException;
+import org.citrusframework.yaks.maven.extension.ExtensionSettings;
+import org.citrusframework.yaks.maven.extension.configuration.json.JsonFileLoggingConfigurationLoader;
+import org.citrusframework.yaks.maven.extension.configuration.properties.PropertyFileLoggingConfigurationLoader;
+import org.citrusframework.yaks.maven.extension.configuration.yaml.YamlFileLoggingConfigurationLoader;
+import org.codehaus.plexus.logging.Logger;
+
+/**
+ * Add dependencies based on configuration living in a external file. Dependency loader delegates to multiple file based
+ * loaders according to the file extension provided as configuration file (e.g. .yaml, .json, .properties).
+ *
+ * User can specify the configuration file to read via System property or environment variable.
+ * @author Christoph Deppisch
+ */
+public class FileBasedLoggingConfigurationLoader implements LoggingConfigurationLoader {
+
+    /** Map of file based config loaders where mapping key is the property file extension */
+    private final Map<String, AbstractConfigFileLoggingConfigurationLoader> fileConfigLoaders;
+
+    public FileBasedLoggingConfigurationLoader() {
+        this.fileConfigLoaders = new HashMap<>();
+
+        fileConfigLoaders.put("yaml", new YamlFileLoggingConfigurationLoader());
+        fileConfigLoaders.put("yml", new YamlFileLoggingConfigurationLoader());
+        fileConfigLoaders.put("json", new JsonFileLoggingConfigurationLoader());
+        fileConfigLoaders.put("properties", new PropertyFileLoggingConfigurationLoader());
+    }
+
+    @Override
+    public Optional<Level> load(ConfigurationBuilder<BuiltConfiguration> builder, Logger logger) throws LifecycleExecutionException {
+        Path settingsFile = getSettingsFile();
+
+        if (Files.exists(settingsFile)) {
+            Optional<String> fileExtension = getFileNameExtension(settingsFile.getFileName().toString());
+            return fileExtension.flatMap(this::getFileConfigLoader)
+                            .orElse(new PropertyFileLoggingConfigurationLoader())
+                            .load(settingsFile, builder, logger);
+        }
+
+        return Optional.empty();
+    }
+
+    private Optional<AbstractConfigFileLoggingConfigurationLoader> getFileConfigLoader(String fileExtension) {
+        return Optional.ofNullable(fileConfigLoaders.get(fileExtension));
+    }
+
+    public static Path getSettingsFile() throws LifecycleExecutionException {
+        String filePath = ExtensionSettings.getSettingsFilePath();
+
+        if (filePath.startsWith("classpath:")) {
+            try {
+                URL resourceUrl = FileBasedLoggingConfigurationLoader.class.getClassLoader().getResource(filePath.substring("classpath:".length()));
+                if (resourceUrl != null) {
+                    return Paths.get(resourceUrl.toURI());
+                }
+            } catch (URISyntaxException e) {
+                throw new LifecycleExecutionException("Unable to locate properties file in classpath", e);
+            }
+        } else if (filePath.startsWith("file:")) {
+            return Paths.get(filePath.substring("file:".length()));
+        }
+
+        return Paths.get(filePath);
+    }
+
+    public static Optional<String> getFileNameExtension(String filename) {
+        return Optional.ofNullable(filename)
+                .filter(f -> f.contains("."))
+                .map(f -> f.substring(filename.lastIndexOf(".") + 1));
+    }
+}

--- a/java/tools/maven/yaks-maven-extension/src/main/java/org/citrusframework/yaks/maven/extension/configuration/LoggingConfigurationLoader.java
+++ b/java/tools/maven/yaks-maven-extension/src/main/java/org/citrusframework/yaks/maven/extension/configuration/LoggingConfigurationLoader.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.yaks.maven.extension.configuration;
+
+import java.util.Optional;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.appender.ConsoleAppender;
+import org.apache.logging.log4j.core.config.LoggerConfig;
+import org.apache.logging.log4j.core.config.builder.api.AppenderComponentBuilder;
+import org.apache.logging.log4j.core.config.builder.api.ConfigurationBuilder;
+import org.apache.logging.log4j.core.config.builder.api.ConfigurationBuilderFactory;
+import org.apache.logging.log4j.core.config.builder.impl.BuiltConfiguration;
+import org.apache.maven.lifecycle.LifecycleExecutionException;
+import org.codehaus.plexus.logging.Logger;
+
+/**
+ * @author Christoph Deppisch
+ */
+@FunctionalInterface
+public interface LoggingConfigurationLoader {
+
+    /**
+     * Load logging configuration from configuration sources.
+     *
+     * @param builder
+     * @param logger
+     * @return root logger level if any is set
+     */
+    Optional<Level> load(ConfigurationBuilder<BuiltConfiguration> builder, Logger logger) throws LifecycleExecutionException;
+
+    /**
+     * Configure logger on given logger context with logger name and level.
+     * @param loggerName
+     * @param level
+     * @param builder
+     * @param logger
+     * @return root logger level if any is set
+     */
+    default Optional<Level> configureLogger(String loggerName, String level, ConfigurationBuilder<BuiltConfiguration> builder, Logger logger) {
+        Level root = null;
+        if (LoggerConfig.ROOT.equals(loggerName)) {
+            root = Level.getLevel(level.toUpperCase());
+        } else {
+            builder.add(builder.newLogger(loggerName, Level.getLevel(level.toUpperCase()))
+                               .add(builder.newAppenderRef("STDOUT"))
+                               .addAttribute("additivity", false));
+            logger.info(String.format("Set logging level %s on logger '%s'", level.toUpperCase(), loggerName));
+        }
+
+        return Optional.ofNullable(root);
+    }
+
+    static ConfigurationBuilder<BuiltConfiguration> newConfigurationBuilder() {
+        final ConfigurationBuilder<BuiltConfiguration> builder = ConfigurationBuilderFactory.newConfigurationBuilder();
+
+        AppenderComponentBuilder appenderBuilder = builder.newAppender("STDOUT", "Console").addAttribute("target",
+                ConsoleAppender.Target.SYSTEM_OUT);
+        appenderBuilder.add(builder.newLayout("PatternLayout")
+                .addAttribute("pattern", "%d{yyyy-MM-dd HH:mm:ss.SSS}|%-5level|%t|%c{1} - %msg%n"));
+        builder.add( appenderBuilder );
+
+        return builder;
+    }
+}

--- a/java/tools/maven/yaks-maven-extension/src/main/java/org/citrusframework/yaks/maven/extension/configuration/env/EnvironmentSettingLoader.java
+++ b/java/tools/maven/yaks-maven-extension/src/main/java/org/citrusframework/yaks/maven/extension/configuration/env/EnvironmentSettingLoader.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.yaks.maven.extension.configuration.env;
+
+import java.util.Optional;
+
+/**
+ * @author Christoph Deppisch
+ */
+public interface EnvironmentSettingLoader {
+
+    /**
+     * Read environment setting. If setting is not present default to empty value.
+     * @param name
+     * @return
+     */
+    default String getEnvSetting(String name) {
+        return Optional.ofNullable(System.getenv(name)).orElse("");
+    }
+}

--- a/java/tools/maven/yaks-maven-extension/src/main/java/org/citrusframework/yaks/maven/extension/configuration/env/EnvironmentSettingRepositoryLoader.java
+++ b/java/tools/maven/yaks-maven-extension/src/main/java/org/citrusframework/yaks/maven/extension/configuration/env/EnvironmentSettingRepositoryLoader.java
@@ -19,7 +19,6 @@ package org.citrusframework.yaks.maven.extension.configuration.env;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
 import org.apache.maven.lifecycle.LifecycleExecutionException;
 import org.apache.maven.model.Repository;
@@ -33,7 +32,7 @@ import org.codehaus.plexus.logging.Logger;
  *
  * @author Christoph Deppisch
  */
-public class EnvironmentSettingRepositoryLoader implements RepositoryLoader {
+public class EnvironmentSettingRepositoryLoader implements RepositoryLoader, EnvironmentSettingLoader {
 
     @Override
     public List<Repository> load(Logger logger) throws LifecycleExecutionException {
@@ -55,14 +54,5 @@ public class EnvironmentSettingRepositoryLoader implements RepositoryLoader {
         }
 
         return repositoryList;
-    }
-
-    /**
-     * Read environment setting. If setting is not present default to empty value.
-     * @param name
-     * @return
-     */
-    protected String getEnvSetting(String name) {
-        return Optional.ofNullable(System.getenv(name)).orElse("");
     }
 }

--- a/java/tools/maven/yaks-maven-extension/src/main/java/org/citrusframework/yaks/maven/extension/configuration/json/JsonFileLoggingConfigurationLoader.java
+++ b/java/tools/maven/yaks-maven-extension/src/main/java/org/citrusframework/yaks/maven/extension/configuration/json/JsonFileLoggingConfigurationLoader.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.yaks.maven.extension.configuration.json;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.config.builder.api.ConfigurationBuilder;
+import org.apache.logging.log4j.core.config.builder.impl.BuiltConfiguration;
+import org.apache.maven.lifecycle.LifecycleExecutionException;
+import org.citrusframework.yaks.maven.extension.configuration.AbstractConfigFileLoggingConfigurationLoader;
+import org.codehaus.plexus.logging.Logger;
+
+/**
+ * Load dependencies from Json configuration file. The configuration should reside as list of Maven artifact dependencies.
+ *
+ * {
+ *   "dependencies": [
+ *     {
+ *       "groupId": "org.foo",
+ *       "artifactId": "foo-artifact",
+ *       "version": "1.0.0"
+ *     },
+ *     {
+ *       "groupId": "org.bar",
+ *       "artifactId": "bar-artifact",
+ *       "version": "1.5.0"
+ *     }
+ *   ]
+ * }
+ *
+ * Each dependency value should be a proper Maven coordinate with groupId, artifactId and version.
+ * @author Christoph Deppisch
+ */
+public class JsonFileLoggingConfigurationLoader extends AbstractConfigFileLoggingConfigurationLoader {
+
+    @Override
+    protected Optional<Level> load(Path filePath, ConfigurationBuilder<BuiltConfiguration> builder, Logger logger) throws LifecycleExecutionException {
+        Level rootLevel = null;
+        ObjectMapper mapper = new ObjectMapper();
+        try {
+            JsonNode root = mapper.readTree(new StringReader(new String(Files.readAllBytes(filePath), StandardCharsets.UTF_8)));
+            ArrayNode loggers = (ArrayNode) root.get("loggers");
+            for (Object o : loggers) {
+                ObjectNode configuration = (ObjectNode) o;
+                String loggerName = configuration.get("name").textValue();
+                String level = configuration.get("level").textValue();
+                rootLevel = configureLogger(loggerName, level, builder, logger).orElse(rootLevel);
+            }
+        } catch (IOException e) {
+            throw new LifecycleExecutionException("Failed to read json config file", e);
+        }
+
+        return Optional.ofNullable(rootLevel);
+    }
+}

--- a/java/tools/maven/yaks-maven-extension/src/main/java/org/citrusframework/yaks/maven/extension/configuration/properties/PropertyFileLoggingConfigurationLoader.java
+++ b/java/tools/maven/yaks-maven-extension/src/main/java/org/citrusframework/yaks/maven/extension/configuration/properties/PropertyFileLoggingConfigurationLoader.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.yaks.maven.extension.configuration.properties;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.config.builder.api.ConfigurationBuilder;
+import org.apache.logging.log4j.core.config.builder.impl.BuiltConfiguration;
+import org.apache.maven.lifecycle.LifecycleExecutionException;
+import org.citrusframework.yaks.maven.extension.ExtensionSettings;
+import org.citrusframework.yaks.maven.extension.configuration.AbstractConfigFileLoggingConfigurationLoader;
+import org.codehaus.plexus.logging.Logger;
+
+/**
+ * @author Christoph Deppisch
+ */
+public class PropertyFileLoggingConfigurationLoader extends AbstractConfigFileLoggingConfigurationLoader {
+
+    @Override
+    protected Optional<Level> load(Path filePath, ConfigurationBuilder<BuiltConfiguration> builder, Logger logger) throws LifecycleExecutionException {
+        Level rootLevel = null;
+        try {
+            Properties properties = new Properties();
+            properties.load(new StringReader(new String(Files.readAllBytes(filePath), StandardCharsets.UTF_8)));
+
+            for (Map.Entry<Object, Object> entry : properties.entrySet()) {
+                if (entry.getValue() == null || !entry.getKey().toString().startsWith(ExtensionSettings.LOGGING_LEVEL_PREFIX)) {
+                    continue;
+                }
+
+                String loggerName = entry.getKey().toString().substring(ExtensionSettings.LOGGING_LEVEL_PREFIX.length());
+                String level = entry.getValue().toString();
+                rootLevel = configureLogger(loggerName, level, builder, logger).orElse(rootLevel);
+            }
+        } catch (IOException e) {
+            throw new LifecycleExecutionException("Failed to load properties from configuration file", e);
+        }
+
+        return Optional.ofNullable(rootLevel);
+    }
+}

--- a/java/tools/maven/yaks-maven-extension/src/main/java/org/citrusframework/yaks/maven/extension/configuration/properties/SystemPropertyLoggingConfigurationLoader.java
+++ b/java/tools/maven/yaks-maven-extension/src/main/java/org/citrusframework/yaks/maven/extension/configuration/properties/SystemPropertyLoggingConfigurationLoader.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.yaks.maven.extension.configuration.properties;
+
+import java.util.Optional;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.config.builder.api.ConfigurationBuilder;
+import org.apache.logging.log4j.core.config.builder.impl.BuiltConfiguration;
+import org.apache.maven.lifecycle.LifecycleExecutionException;
+import org.citrusframework.yaks.maven.extension.ExtensionSettings;
+import org.citrusframework.yaks.maven.extension.configuration.LoggingConfigurationLoader;
+import org.codehaus.plexus.logging.Logger;
+
+/**
+ * Loader reads additional dependency coordinates from system property setting. If system property is present the loader
+ * expects the value to be a comma separated list of Maven coordinate scalars of form 'groupId:artifactId:version'.
+ *
+ * @author Christoph Deppisch
+ */
+public class SystemPropertyLoggingConfigurationLoader implements LoggingConfigurationLoader {
+
+    @Override
+    public Optional<Level> load(ConfigurationBuilder<BuiltConfiguration> builder, Logger logger) throws LifecycleExecutionException {
+        Level rootLevel = null;
+        String loggers = System.getProperty(ExtensionSettings.LOGGERS_SETTING_KEY, "");
+
+        if (loggers.length() > 0) {
+            for (String configuration : loggers.split(",")) {
+                String loggerName=configuration.split("=")[0];
+                String level=configuration.split("=")[1];
+                rootLevel = configureLogger(loggerName, level, builder, logger).orElse(rootLevel);
+            }
+        }
+
+        return Optional.ofNullable(rootLevel);
+    }
+}

--- a/java/tools/maven/yaks-maven-extension/src/main/java/org/citrusframework/yaks/maven/extension/configuration/yaml/YamlFileLoggingConfigurationLoader.java
+++ b/java/tools/maven/yaks-maven-extension/src/main/java/org/citrusframework/yaks/maven/extension/configuration/yaml/YamlFileLoggingConfigurationLoader.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.yaks.maven.extension.configuration.yaml;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.config.builder.api.ConfigurationBuilder;
+import org.apache.logging.log4j.core.config.builder.impl.BuiltConfiguration;
+import org.apache.maven.lifecycle.LifecycleExecutionException;
+import org.citrusframework.yaks.maven.extension.configuration.AbstractConfigFileLoggingConfigurationLoader;
+import org.codehaus.plexus.logging.Logger;
+import org.yaml.snakeyaml.Yaml;
+
+/**
+ * Yaml configuration file loader is supposed to have one to many entries that unmarshal to a Maven dependency model:
+ *
+ * dependencies
+ *   - groupId: org.foo
+ *     artifactId: foo
+ *     version: 1.0.0
+ *   - groupId: org.bar
+ *     artifactId: bar
+ *     version: 1.2.0
+ *
+ * Each dependency value should be a proper Maven coordinate with groupId, artifactId and version.
+ * @author Christoph Deppisch
+ */
+public class YamlFileLoggingConfigurationLoader extends AbstractConfigFileLoggingConfigurationLoader {
+
+    @Override
+    protected Optional<Level> load(Path filePath, ConfigurationBuilder<BuiltConfiguration> builder, Logger logger) throws LifecycleExecutionException {
+        Level rootLevel = null;
+        try {
+            Yaml yaml = new Yaml();
+
+            HashMap<String, List<Map<String, Object>>> root = yaml.load(new StringReader(new String(Files.readAllBytes(filePath), StandardCharsets.UTF_8)));
+            if (root.containsKey("loggers")) {
+                for (Map<String, Object> configuration : root.get("loggers")) {
+                    String loggerName = Objects.toString(configuration.get("name"));
+                    String level = Objects.toString(configuration.get("level"));
+                    rootLevel = configureLogger(loggerName, level, builder, logger).orElse(rootLevel);
+                }
+            }
+        } catch (IOException e) {
+            throw new LifecycleExecutionException("Failed to read dependency configuration file", e);
+        }
+
+        return Optional.ofNullable(rootLevel);
+    }
+}

--- a/java/tools/maven/yaks-maven-extension/src/test/java/org/citrusframework/yaks/maven/extension/configuration/FileBasedLoggingConfigurationLoaderTest.java
+++ b/java/tools/maven/yaks-maven-extension/src/test/java/org/citrusframework/yaks/maven/extension/configuration/FileBasedLoggingConfigurationLoaderTest.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.yaks.maven.extension.configuration;
+
+import java.util.Optional;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.config.builder.api.ConfigurationBuilder;
+import org.apache.logging.log4j.core.config.builder.impl.BuiltConfiguration;
+import org.apache.maven.lifecycle.LifecycleExecutionException;
+import org.citrusframework.yaks.maven.extension.ExtensionSettings;
+import org.codehaus.plexus.logging.console.ConsoleLogger;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author Christoph Deppisch
+ */
+public class FileBasedLoggingConfigurationLoaderTest {
+
+    private FileBasedLoggingConfigurationLoader loader = new FileBasedLoggingConfigurationLoader();
+
+    private ConsoleLogger logger = new ConsoleLogger();
+    private ConfigurationBuilder<BuiltConfiguration> builder;
+
+    @Test
+    public void shouldLoadFromPropertyFile() throws LifecycleExecutionException {
+        System.setProperty(ExtensionSettings.SETTINGS_FILE_KEY, "classpath:yaks.properties");
+        builder = LoggingConfigurationLoader.newConfigurationBuilder();
+        Optional<Level> rootLevel = loader.load(builder, logger);
+        Assert.assertTrue(rootLevel.isPresent());
+        Assert.assertEquals(Level.INFO, rootLevel.get());
+        TestHelper.verifyLoggingConfiguration(builder);
+
+        System.setProperty(ExtensionSettings.SETTINGS_FILE_KEY, "classpath:yaks.settings.yaml");
+        builder = LoggingConfigurationLoader.newConfigurationBuilder();
+        rootLevel = loader.load(builder, logger);
+        Assert.assertTrue(rootLevel.isPresent());
+        Assert.assertEquals(Level.INFO, rootLevel.get());
+        TestHelper.verifyLoggingConfiguration(builder);
+
+        System.setProperty(ExtensionSettings.SETTINGS_FILE_KEY, "classpath:yaks.settings.json");
+        builder = LoggingConfigurationLoader.newConfigurationBuilder();
+        rootLevel = loader.load(builder, logger);
+        Assert.assertTrue(rootLevel.isPresent());
+        Assert.assertEquals(Level.INFO, rootLevel.get());
+        TestHelper.verifyLoggingConfiguration(builder);
+    }
+
+    @Test
+    public void shouldHandleNonExistingFile() throws LifecycleExecutionException {
+        System.setProperty(ExtensionSettings.SETTINGS_FILE_KEY, "doesNotExist");
+        builder = LoggingConfigurationLoader.newConfigurationBuilder();
+        Optional<Level> rootLevel = loader.load(builder, logger);
+        Assert.assertFalse(rootLevel.isPresent());
+        TestHelper.verifyDefaultLoggingConfiguration(builder);
+    }
+
+}

--- a/java/tools/maven/yaks-maven-extension/src/test/java/org/citrusframework/yaks/maven/extension/configuration/TestHelper.java
+++ b/java/tools/maven/yaks-maven-extension/src/test/java/org/citrusframework/yaks/maven/extension/configuration/TestHelper.java
@@ -17,15 +17,20 @@
 
 package org.citrusframework.yaks.maven.extension.configuration;
 
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.Objects;
 
+import org.apache.logging.log4j.core.config.builder.api.ConfigurationBuilder;
+import org.apache.logging.log4j.core.config.builder.impl.BuiltConfiguration;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.model.Repository;
 import org.assertj.core.api.Assertions;
+import org.junit.Assert;
 
 /**
  * @author Christoph Deppisch
@@ -90,5 +95,51 @@ public final class TestHelper {
         Assertions.assertThat(repositoryList).anyMatch(repository -> repository.getUrl().equals(central.getUrl()));
         Assertions.assertThat(repositoryList).anyMatch(repository -> repository.getId().equals(jboss.getId()));
         Assertions.assertThat(repositoryList).anyMatch(repository -> repository.getUrl().equals(jboss.getUrl()));
+    }
+
+    public static void verifyDefaultLoggingConfiguration(ConfigurationBuilder<BuiltConfiguration> builder) {
+        String log4j2 = "<?xml version=\"1.0\" ?>" + System.lineSeparator() +
+            "<Configuration>" + System.lineSeparator() +
+            "  <Appenders>" + System.lineSeparator() +
+            "    <Console name=\"STDOUT\" target=\"SYSTEM_OUT\">" + System.lineSeparator() +
+            "      <PatternLayout pattern=\"%d{yyyy-MM-dd HH:mm:ss.SSS}|%-5level|%t|%c{1} - %msg%n\"/>" + System.lineSeparator() +
+            "    </Console>" + System.lineSeparator() +
+            "  </Appenders>" + System.lineSeparator() +
+            "</Configuration>" + System.lineSeparator();
+
+        ByteArrayOutputStream result = new ByteArrayOutputStream();
+        try {
+            builder.writeXmlConfiguration(result);
+            Assert.assertEquals(log4j2, new String(result.toByteArray()));
+        } catch (IOException e) {
+            Assert.fail(String.format("Failed to write logging configuration as XML - %s", e.getMessage()));
+        }
+    }
+
+    public static void verifyLoggingConfiguration(ConfigurationBuilder<BuiltConfiguration> builder) {
+        String log4j2 = "<?xml version=\"1.0\" ?>" + System.lineSeparator() +
+            "<Configuration>" + System.lineSeparator() +
+            "  <Appenders>" + System.lineSeparator() +
+            "    <Console name=\"STDOUT\" target=\"SYSTEM_OUT\">" + System.lineSeparator() +
+            "      <PatternLayout pattern=\"%d{yyyy-MM-dd HH:mm:ss.SSS}|%-5level|%t|%c{1} - %msg%n\"/>" + System.lineSeparator() +
+            "    </Console>" + System.lineSeparator() +
+            "  </Appenders>" + System.lineSeparator() +
+            "  <Loggers>" + System.lineSeparator() +
+            "    <Logger name=\"org.foo\" level=\"DEBUG\" additivity=\"false\">" + System.lineSeparator() +
+            "      <AppenderRef ref=\"STDOUT\"/>" + System.lineSeparator() +
+            "    </Logger>" + System.lineSeparator() +
+            "    <Logger name=\"org.bar\" level=\"WARN\" additivity=\"false\">" + System.lineSeparator() +
+            "      <AppenderRef ref=\"STDOUT\"/>" + System.lineSeparator() +
+            "    </Logger>" + System.lineSeparator() +
+            "  </Loggers>" + System.lineSeparator() +
+            "</Configuration>" + System.lineSeparator();
+
+        ByteArrayOutputStream result = new ByteArrayOutputStream();
+        try {
+            builder.writeXmlConfiguration(result);
+            Assert.assertEquals(log4j2, new String(result.toByteArray()));
+        } catch (IOException e) {
+            Assert.fail(String.format("Failed to write logging configuration as XML - %s", e.getMessage()));
+        }
     }
 }

--- a/java/tools/maven/yaks-maven-extension/src/test/java/org/citrusframework/yaks/maven/extension/configuration/env/EnvironmentSettingDependencyLoaderTest.java
+++ b/java/tools/maven/yaks-maven-extension/src/test/java/org/citrusframework/yaks/maven/extension/configuration/env/EnvironmentSettingDependencyLoaderTest.java
@@ -39,7 +39,7 @@ public class EnvironmentSettingDependencyLoaderTest {
     public void shouldLoadFromEnv() throws LifecycleExecutionException {
         EnvironmentSettingDependencyLoader loader = new EnvironmentSettingDependencyLoader() {
             @Override
-            protected String getEnvSetting(String name) {
+            public String getEnvSetting(String name) {
                 return "org.foo:foo-artifact:1.0.0,org.bar:bar-artifact:1.5.0";
             }
         };
@@ -52,7 +52,7 @@ public class EnvironmentSettingDependencyLoaderTest {
     public void shouldLoadFromEnvWithVersionResolving() throws LifecycleExecutionException {
         EnvironmentSettingDependencyLoader loader = new EnvironmentSettingDependencyLoader() {
             @Override
-            protected String getEnvSetting(String name) {
+            public String getEnvSetting(String name) {
                 return "org.foo:foo-artifact:@foo.version@,org.bar:bar-artifact:@bar.version@";
             }
         };

--- a/java/tools/maven/yaks-maven-extension/src/test/java/org/citrusframework/yaks/maven/extension/configuration/json/JsonFileLoggingConfigurationLoaderTest.java
+++ b/java/tools/maven/yaks-maven-extension/src/test/java/org/citrusframework/yaks/maven/extension/configuration/json/JsonFileLoggingConfigurationLoaderTest.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.yaks.maven.extension.configuration.json;
+
+import java.net.URISyntaxException;
+import java.nio.file.Paths;
+import java.util.Optional;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.config.builder.api.ConfigurationBuilder;
+import org.apache.logging.log4j.core.config.builder.impl.BuiltConfiguration;
+import org.apache.maven.lifecycle.LifecycleExecutionException;
+import org.assertj.core.api.Assertions;
+import org.citrusframework.yaks.maven.extension.configuration.LoggingConfigurationLoader;
+import org.citrusframework.yaks.maven.extension.configuration.TestHelper;
+import org.codehaus.plexus.logging.console.ConsoleLogger;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author Christoph Deppisch
+ */
+public class JsonFileLoggingConfigurationLoaderTest {
+
+    private JsonFileLoggingConfigurationLoader loader = new JsonFileLoggingConfigurationLoader();
+
+    private ConsoleLogger logger = new ConsoleLogger();
+    private final ConfigurationBuilder<BuiltConfiguration> builder = LoggingConfigurationLoader.newConfigurationBuilder();
+
+    @Test
+    public void shouldLoadFromJson() throws LifecycleExecutionException, URISyntaxException {
+        Optional<Level> rootLevel = loader.load(TestHelper.getClasspathResource("yaks.settings.json"), builder, logger);
+        Assert.assertTrue(rootLevel.isPresent());
+        Assert.assertEquals(Level.INFO, rootLevel.get());
+
+        TestHelper.verifyLoggingConfiguration(builder);
+    }
+
+    @Test
+    public void shouldHandleNonExistingJson() {
+        Assertions.assertThatExceptionOfType(LifecycleExecutionException.class)
+                .isThrownBy(() -> loader.load(Paths.get("doesNotExist"), builder, logger));
+    }
+}

--- a/java/tools/maven/yaks-maven-extension/src/test/java/org/citrusframework/yaks/maven/extension/configuration/properties/PropertyFileLoggingConfigurationLoaderTest.java
+++ b/java/tools/maven/yaks-maven-extension/src/test/java/org/citrusframework/yaks/maven/extension/configuration/properties/PropertyFileLoggingConfigurationLoaderTest.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.yaks.maven.extension.configuration.properties;
+
+import java.net.URISyntaxException;
+import java.nio.file.Paths;
+import java.util.Optional;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.config.builder.api.ConfigurationBuilder;
+import org.apache.logging.log4j.core.config.builder.impl.BuiltConfiguration;
+import org.apache.maven.lifecycle.LifecycleExecutionException;
+import org.assertj.core.api.Assertions;
+import org.citrusframework.yaks.maven.extension.configuration.LoggingConfigurationLoader;
+import org.citrusframework.yaks.maven.extension.configuration.TestHelper;
+import org.codehaus.plexus.logging.console.ConsoleLogger;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author Christoph Deppisch
+ */
+public class PropertyFileLoggingConfigurationLoaderTest {
+
+    private PropertyFileLoggingConfigurationLoader loader = new PropertyFileLoggingConfigurationLoader();
+
+    private ConsoleLogger logger = new ConsoleLogger();
+    private final ConfigurationBuilder<BuiltConfiguration> builder = LoggingConfigurationLoader.newConfigurationBuilder();
+
+    @Test
+    public void shouldLoadFromPropertyFile() throws LifecycleExecutionException, URISyntaxException {
+        Optional<Level> rootLevel = loader.load(TestHelper.getClasspathResource("yaks.properties"), builder, logger);
+        Assert.assertTrue(rootLevel.isPresent());
+        Assert.assertEquals(Level.INFO, rootLevel.get());
+
+        TestHelper.verifyLoggingConfiguration(builder);
+    }
+
+    @Test
+    public void shouldHandleNonExistingFile() {
+        Assertions.assertThatExceptionOfType(LifecycleExecutionException.class)
+                .isThrownBy(() -> loader.load(Paths.get("doesNotExist"), builder, logger));
+    }
+
+}

--- a/java/tools/maven/yaks-maven-extension/src/test/java/org/citrusframework/yaks/maven/extension/configuration/yaml/YamlFileLoggingConfigurationLoaderTest.java
+++ b/java/tools/maven/yaks-maven-extension/src/test/java/org/citrusframework/yaks/maven/extension/configuration/yaml/YamlFileLoggingConfigurationLoaderTest.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.yaks.maven.extension.configuration.yaml;
+
+import java.net.URISyntaxException;
+import java.nio.file.Paths;
+import java.util.Optional;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.config.builder.api.ConfigurationBuilder;
+import org.apache.logging.log4j.core.config.builder.impl.BuiltConfiguration;
+import org.apache.maven.lifecycle.LifecycleExecutionException;
+import org.assertj.core.api.Assertions;
+import org.citrusframework.yaks.maven.extension.configuration.LoggingConfigurationLoader;
+import org.citrusframework.yaks.maven.extension.configuration.TestHelper;
+import org.codehaus.plexus.logging.console.ConsoleLogger;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author Christoph Deppisch
+ */
+public class YamlFileLoggingConfigurationLoaderTest {
+
+    private YamlFileLoggingConfigurationLoader loader = new YamlFileLoggingConfigurationLoader();
+
+    private ConsoleLogger logger = new ConsoleLogger();
+    private final ConfigurationBuilder<BuiltConfiguration> builder = LoggingConfigurationLoader.newConfigurationBuilder();
+
+    @Test
+    public void shouldLoadFromYaml() throws LifecycleExecutionException, URISyntaxException {
+        Optional<Level> rootLevel = loader.load(TestHelper.getClasspathResource("yaks.settings.yaml"), builder, logger);
+        Assert.assertTrue(rootLevel.isPresent());
+        Assert.assertEquals(Level.INFO, rootLevel.get());
+
+        TestHelper.verifyLoggingConfiguration(builder);
+    }
+
+    @Test
+    public void shouldHandleNonExistingYaml() {
+        Assertions.assertThatExceptionOfType(LifecycleExecutionException.class)
+                .isThrownBy(() -> loader.load(Paths.get("doesNotExist"), builder, logger));
+    }
+}

--- a/java/tools/maven/yaks-maven-extension/src/test/resources/log4j2-test.xml
+++ b/java/tools/maven/yaks-maven-extension/src/test/resources/log4j2-test.xml
@@ -28,7 +28,7 @@
     </Root>
 
     <!-- Our own classes-->
-    <Logger name="org.citrusframework.yaks" additivity="false" level="DEBUG">
+    <Logger name="org.citrusframework.yaks" additivity="false" level="INFO">
       <AppenderRef ref="STDOUT"/>
     </Logger>
 

--- a/java/tools/maven/yaks-maven-extension/src/test/resources/yaks.settings.json
+++ b/java/tools/maven/yaks-maven-extension/src/test/resources/yaks.settings.json
@@ -30,5 +30,19 @@
       "artifactId": "bar-artifact",
       "version": "1.5.0"
     }
+  ],
+  "loggers": [
+    {
+      "name": "root",
+      "level": "INFO"
+    },
+    {
+      "name": "org.foo",
+      "level": "DEBUG"
+    },
+    {
+      "name": "org.bar",
+      "level": "WARN"
+    }
   ]
 }

--- a/java/tools/maven/yaks-maven-extension/src/test/resources/yaks.settings.yaml
+++ b/java/tools/maven/yaks-maven-extension/src/test/resources/yaks.settings.yaml
@@ -35,3 +35,10 @@ dependencies:
   - groupId: org.bar
     artifactId: bar-artifact
     version: 1.5.0
+loggers:
+  - name: root
+    level: INFO
+  - name: org.foo
+    level: DEBUG
+  - name: org.bar
+    level: WARN

--- a/pkg/cmd/config/config.go
+++ b/pkg/cmd/config/config.go
@@ -65,6 +65,7 @@ type EnvConfig struct {
 type SettingsConfig struct {
 	Repositories []RepositoryConfig
 	Dependencies []DependencyConfig
+	Loggers 	 []LoggerConfig
 }
 
 type RepositoryConfig struct {
@@ -80,10 +81,16 @@ type PolicyConfig struct {
 	Enabled      string `yaml:"enabled,omitempty"`
 	UpdatePolicy string `yaml:"updatePolicy,omitempty"`
 }
+
 type DependencyConfig struct {
 	GroupId    string `yaml:"groupId"`
 	ArtifactId string `yaml:"artifactId"`
 	Version    string `yaml:"version"`
+}
+
+type LoggerConfig struct {
+	Name  string `yaml:"name"`
+	Level string `yaml:"level"`
 }
 
 type NamespaceConfig struct {

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -29,8 +29,8 @@ import (
 )
 
 const (
-	ConfigNameEnv       = "YAKS_CONFIG_NAME"
-	ConfigPathEnv    = "YAKS_CONFIG_PATH"
+	ConfigNameEnv = "YAKS_CONFIG_NAME"
+	ConfigPathEnv = "YAKS_CONFIG_PATH"
 
 	commandShortDescription = `YAKS is a client tool for running tests natively on Kubernetes`
 	commandLongDescription = `YAKS is a platform to enable Cloud Native BDD testing on Kubernetes.`

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -62,6 +62,7 @@ func NewYaksCommand(ctx context.Context) (*cobra.Command, error) {
 		Use:   "yaks",
 		Short: commandShortDescription,
 		Long:  commandLongDescription,
+		SilenceUsage: true,
 	}
 
 	cmd.PersistentFlags().StringVar(&options.KubeConfig, "config", os.Getenv("KUBECONFIG"), "Path to the config file to use for CLI requests")

--- a/pkg/cmd/test.go
+++ b/pkg/cmd/test.go
@@ -547,7 +547,9 @@ func (o *testCmdOptions) newSettings(runConfig *config.RunConfig) (*v1alpha1.Set
 		return &settings, nil
 	}
 
-	if len(runConfig.Config.Runtime.Settings.Dependencies) > 0 || len(runConfig.Config.Runtime.Settings.Repositories) > 0 {
+	if len(runConfig.Config.Runtime.Settings.Dependencies) > 0 ||
+		len(runConfig.Config.Runtime.Settings.Repositories) > 0 ||
+		len(runConfig.Config.Runtime.Settings.Loggers) > 0 {
 		configData, err := yaml.Marshal(runConfig.Config.Runtime.Settings)
 
 		if err != nil {

--- a/pkg/cmd/test.go
+++ b/pkg/cmd/test.go
@@ -63,6 +63,7 @@ const (
 	NamespaceEnv       = "YAKS_NAMESPACE"
 	RepositoriesEnv    = "YAKS_REPOSITORIES"
 	DependenciesEnv    = "YAKS_DEPENDENCIES"
+	LoggersEnv         = "YAKS_LOGGERS"
 
 	CucumberOptions    = "CUCUMBER_OPTIONS"
 	CucumberGlue       = "CUCUMBER_GLUE"
@@ -87,6 +88,7 @@ func newCmdTest(rootCmdOptions *RootCmdOptions) (*cobra.Command, *testCmdOptions
 	}
 
 	cmd.Flags().StringArray("maven-repository", nil, "Adds custom Maven repository URL that is added to the runtime.")
+	cmd.Flags().StringArrayP("logger", "l", nil, "Adds logger configuration setting log levels.")
 	cmd.Flags().StringArrayP("dependency", "d", nil, "Adds runtime dependencies that get automatically loaded before the test is executed.")
 	cmd.Flags().StringArrayP("upload", "u", nil, "Upload a given library to the cluster to allow it to be used by tests.")
 	cmd.Flags().StringP("settings", "s", "", "Path to runtime settings file. File content is added to the test runtime and can hold runtime dependency information for instance.")
@@ -105,6 +107,7 @@ type testCmdOptions struct {
 	*RootCmdOptions
 	Repositories []string `mapstructure:"maven-repository"`
 	Dependencies []string `mapstructure:"dependency"`
+	Logger       []string `mapstructure:"logger"`
 	Uploads      []string `mapstructure:"upload"`
 	Settings     string `mapstructure:"settings"`
 	Env          []string `mapstructure:"env"`
@@ -512,6 +515,10 @@ func (o *testCmdOptions) setupEnvSettings(test *v1alpha1.Test, runConfig *config
 
 	if len(o.Dependencies) > 0 {
 		env = append(env, DependenciesEnv+"="+strings.Join(o.Dependencies, ","))
+	}
+
+	if len(o.Logger) > 0 {
+		env = append(env, LoggersEnv+"="+strings.Join(o.Logger, ","))
 	}
 
 	for _, envConfig := range runConfig.Config.Runtime.Env {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -24,7 +24,7 @@ import (
 )
 
 func GetTestBaseImage() string {
-	customEnv := os.Getenv("TEST_BASE_IMAGE")
+	customEnv := os.Getenv("YAKS_TEST_BASE_IMAGE")
 	if customEnv != "" {
 		return customEnv
 	}

--- a/pkg/controller/test/start.go
+++ b/pkg/controller/test/start.go
@@ -107,16 +107,7 @@ func (action *startAction) newTestingPod(ctx context.Context, test *v1alpha1.Tes
 				{
 					Name:  "test",
 					Image: config.GetTestBaseImage(),
-					Command: []string{
-						"mvn",
-						"-f",
-						"/deployments/data/yaks-runtime-maven",
-						"-Dremoteresources.skip=true",
-						"-Dmaven.repo.local=/deployments/artifacts/m2",
-						"-s",
-						"/deployments/artifacts/settings.xml",
-						"test",
-					},
+					Command: getMavenArgLine(),
 					TerminationMessagePolicy: "FallbackToLogsOnError",
 					TerminationMessagePath:   "/dev/termination-log",
 					ImagePullPolicy:          v1.PullIfNotPresent,
@@ -191,6 +182,28 @@ func (action *startAction) newTestingPod(ctx context.Context, test *v1alpha1.Tes
 	}
 
 	return &pod, nil
+}
+
+func getMavenArgLine() []string {
+	argLine := make([]string, 0)
+
+	// add base flags
+	argLine = append(argLine, "mvn", "-B", "-q")
+
+	// add pom file path
+	argLine = append(argLine, "-f", "/deployments/data/yaks-runtime-maven")
+
+	// add settings file
+	argLine = append(argLine, "-s", "/deployments/artifacts/settings.xml")
+
+	// add test goal
+	argLine = append(argLine, "test")
+
+	// add system property settings
+	argLine = append(argLine, "-Dremoteresources.skip=true", "-Dmaven.repo.local=/deployments/artifacts/m2")
+
+
+	return argLine
 }
 
 func (action *startAction) newTestingConfigMap(ctx context.Context, test *v1alpha1.Test) *v1.ConfigMap {


### PR DESCRIPTION
Fixes #139 

Sharpen log output to substantial info by using ERROR root log level by default. Users can enable more detailed log output by adding logger configuration to the YAKS command or as config setting.

*CLI option*
```
$ yaks test hello-world.feature --logger org.citrusframework.yaks=DEBUG
```

*yaks-config.yaml*
```
config:
  runtime:
    settings:
      loggers:
        - name: root
          level: INFO
        - name: org.citrusframework.yaks
          level: DEBUG
        - name: com.consol.citrus
          level: INFO
```

By default log output is reduced to:

```
yaks test examples/helloworld.feature 
test "helloworld" updated
+ test-helloworld-bu0a6pj7qr2k805ou1s0 › test
test-helloworld-bu0a6pj7qr2k805ou1s0 test INFO	| 
test-helloworld-bu0a6pj7qr2k805ou1s0 test INFO	| ------------------------------------------------------------------------
test-helloworld-bu0a6pj7qr2k805ou1s0 test INFO	|        .__  __                       
test-helloworld-bu0a6pj7qr2k805ou1s0 test INFO	|   ____ |__|/  |________ __ __  ______
test-helloworld-bu0a6pj7qr2k805ou1s0 test INFO	| _/ ___\|  \   __\_  __ \  |  \/  ___/
test-helloworld-bu0a6pj7qr2k805ou1s0 test INFO	| \  \___|  ||  |  |  | \/  |  /\___ \ 
test-helloworld-bu0a6pj7qr2k805ou1s0 test INFO	|  \___  >__||__|  |__|  |____//____  >
test-helloworld-bu0a6pj7qr2k805ou1s0 test INFO	|      \/                           \/
test-helloworld-bu0a6pj7qr2k805ou1s0 test INFO	| 
test-helloworld-bu0a6pj7qr2k805ou1s0 test INFO	| C I T R U S  T E S T S  3.0.0-M1
test-helloworld-bu0a6pj7qr2k805ou1s0 test INFO	| 
test-helloworld-bu0a6pj7qr2k805ou1s0 test INFO	| ------------------------------------------------------------------------
test-helloworld-bu0a6pj7qr2k805ou1s0 test INFO	| 
test-helloworld-bu0a6pj7qr2k805ou1s0 test 
test-helloworld-bu0a6pj7qr2k805ou1s0 test Scenario: Print YAKS slogan                # org/citrusframework/yaks/helloworld.feature:3
test-helloworld-bu0a6pj7qr2k805ou1s0 test   Given YAKS does Cloud-Native BDD testing # org.citrusframework.yaks.standard.StandardSteps.itDoesBDD()
test-helloworld-bu0a6pj7qr2k805ou1s0 test   Then YAKS rocks!                         # org.citrusframework.yaks.standard.StandardSteps.yaksRocks()
test-helloworld-bu0a6pj7qr2k805ou1s0 test 
test-helloworld-bu0a6pj7qr2k805ou1s0 test Scenario: Print message          # org/citrusframework/yaks/helloworld.feature:7
test-helloworld-bu0a6pj7qr2k805ou1s0 test   Given print 'Hello from YAKS!' # org.citrusframework.yaks.standard.StandardSteps.print(java.lang.String)
test-helloworld-bu0a6pj7qr2k805ou1s0 test INFO	| ------------------------------------------------------------------------
test-helloworld-bu0a6pj7qr2k805ou1s0 test INFO	| 
test-helloworld-bu0a6pj7qr2k805ou1s0 test INFO	| CITRUS TEST RESULTS
test-helloworld-bu0a6pj7qr2k805ou1s0 test INFO	| 
test-helloworld-bu0a6pj7qr2k805ou1s0 test INFO	|  Print YAKS slogan .............................................. SUCCESS
test-helloworld-bu0a6pj7qr2k805ou1s0 test INFO	|  Print message .................................................. SUCCESS
test-helloworld-bu0a6pj7qr2k805ou1s0 test INFO	| 
test-helloworld-bu0a6pj7qr2k805ou1s0 test INFO	| TOTAL:	2
test-helloworld-bu0a6pj7qr2k805ou1s0 test INFO	| FAILED:	0 (0.0%)
test-helloworld-bu0a6pj7qr2k805ou1s0 test INFO	| SUCCESS:	2 (100.0%)
test-helloworld-bu0a6pj7qr2k805ou1s0 test INFO	| 
test-helloworld-bu0a6pj7qr2k805ou1s0 test INFO	| ------------------------------------------------------------------------
test-helloworld-bu0a6pj7qr2k805ou1s0 test 
test-helloworld-bu0a6pj7qr2k805ou1s0 test 2 Scenarios (2 passed)
test-helloworld-bu0a6pj7qr2k805ou1s0 test 3 Steps (3 passed)
test-helloworld-bu0a6pj7qr2k805ou1s0 test 0m2.774s
test-helloworld-bu0a6pj7qr2k805ou1s0 test 
test-helloworld-bu0a6pj7qr2k805ou1s0 test 
Test Passed
Test results: Total: 2, Passed: 2, Failed: 0, Skipped: 0
	Print YAKS slogan (helloworld.feature:3): Passed
	Print message (helloworld.feature:7): Passed
```