### PR TITLE
fix: Knative steps improvements

### DIFF
--- a/examples/knative/knative-eventing.feature
+++ b/examples/knative/knative-eventing.feature
@@ -1,15 +1,13 @@
 Feature: Knative eventing
 
   Background:
-    Given Knative broker URL: http://broker-ingress.knative-eventing.svc.cluster.local/event-example/default
     Given Knative event consumer timeout is 20000 ms
-    Given create Knative broker default
     Given Knative broker default is running
     Given variable id is "citrus:randomNumber(4)"
 
   Scenario: Service trigger
     Given create Knative event consumer service hello-service
-    Given create Knative trigger hello-trigger on service hello-service with filter on attributes
+    Given create Knative trigger hello-service-trigger on service hello-service with filter on attributes
       | type   | service-greeting |
       | source | https://github.com/citrusframework/yaks |
     When Knative event data: {"msg": "Hello Knative!"}
@@ -29,7 +27,7 @@ Feature: Knative eventing
     Given create Knative channel hello-channel
     Given create Knative event consumer service hello-service
     Given subscribe service hello-service to Knative channel hello-channel
-    Given create Knative trigger hello-trigger on channel hello-channel with filter on attributes
+    Given create Knative trigger hello-channel-trigger on channel hello-channel with filter on attributes
       | type   | channel-greeting |
       | source | https://github.com/citrusframework/yaks |
     When Knative event data: {"msg": "Hello Knative!"}

--- a/examples/knative/yaks-config.yaml
+++ b/examples/knative/yaks-config.yaml
@@ -1,0 +1,26 @@
+# ---------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ---------------------------------------------------------------------------
+
+config:
+  runtime:
+    settings:
+      loggers:
+        - name: Logger.Message_IN
+          level: DEBUG
+        - name: Logger.Message_OUT
+          level: DEBUG
+

--- a/java/steps/yaks-knative/src/main/java/org/citrusframework/yaks/knative/KnativeSettings.java
+++ b/java/steps/yaks-knative/src/main/java/org/citrusframework/yaks/knative/KnativeSettings.java
@@ -43,6 +43,10 @@ public class KnativeSettings {
     private static final String NAMESPACE_PROPERTY = KNATIVE_PROPERTY_PREFIX + "namespace";
     private static final String NAMESPACE_ENV = KNATIVE_ENV_PREFIX + "NAMESPACE";
 
+    private static final String API_VERSION_PROPERTY = KNATIVE_PROPERTY_PREFIX + "api.version";
+    private static final String API_VERSION_ENV = KNATIVE_ENV_PREFIX + "API_VERSION";
+    private static final String API_VERSION_DEFAULT = "v1beta1";
+
     private static final String BROKER_HOST_PROPERTY = KNATIVE_PROPERTY_PREFIX + "broker.host";
     private static final String BROKER_HOST_ENV = KNATIVE_ENV_PREFIX + "BROKER_HOST";
     private static final String BROKER_HOST_DEFAULT = String.format("broker-ingress.knative-eventing.%s", YaksSettings.DEFAULT_DOMAIN_SUFFIX);
@@ -102,6 +106,15 @@ public class KnativeSettings {
     public static String getNamespace() {
         return System.getProperty(NAMESPACE_PROPERTY,
                 System.getenv(NAMESPACE_ENV) != null ? System.getenv(NAMESPACE_ENV) : YaksSettings.getDefaultNamespace());
+    }
+
+    /**
+     * Api version for current Knative installation.
+     * @return
+     */
+    public static String getApiVersion() {
+        return System.getProperty(API_VERSION_PROPERTY,
+                System.getenv(API_VERSION_ENV) != null ? System.getenv(API_VERSION_ENV) : API_VERSION_DEFAULT);
     }
 
     /**

--- a/java/steps/yaks-knative/src/main/java/org/citrusframework/yaks/knative/KnativeSettings.java
+++ b/java/steps/yaks-knative/src/main/java/org/citrusframework/yaks/knative/KnativeSettings.java
@@ -49,7 +49,8 @@ public class KnativeSettings {
 
     private static final String BROKER_HOST_PROPERTY = KNATIVE_PROPERTY_PREFIX + "broker.host";
     private static final String BROKER_HOST_ENV = KNATIVE_ENV_PREFIX + "BROKER_HOST";
-    private static final String BROKER_HOST_DEFAULT = String.format("broker-ingress.knative-eventing.%s", YaksSettings.DEFAULT_DOMAIN_SUFFIX);
+    private static final String BROKER_HOST_KUBERNETES_DEFAULT = String.format("broker-ingress.knative-eventing.%s", YaksSettings.DEFAULT_DOMAIN_SUFFIX);
+    private static final String BROKER_HOST_OPENSHIFT_DEFAULT = String.format("${%s}-broker.%s.%s", KnativeVariableNames.BROKER_NAME.value(), getNamespace(), YaksSettings.DEFAULT_DOMAIN_SUFFIX);
 
     private static final String BROKER_NAME_PROPERTY = KNATIVE_PROPERTY_PREFIX + "broker.name";
     private static final String BROKER_NAME_ENV = KNATIVE_ENV_PREFIX + "BROKER_NAME";
@@ -122,8 +123,11 @@ public class KnativeSettings {
      * @return
      */
     public static String getBrokerHost() {
+        String brokerHostDefault = YaksSettings.isOpenshiftCluster() ?
+                BROKER_HOST_OPENSHIFT_DEFAULT :
+                BROKER_HOST_KUBERNETES_DEFAULT;
         return System.getProperty(BROKER_HOST_PROPERTY,
-                System.getenv(BROKER_HOST_ENV) != null ? System.getenv(BROKER_HOST_ENV) : BROKER_HOST_DEFAULT);
+                System.getenv(BROKER_HOST_ENV) != null ? System.getenv(BROKER_HOST_ENV) : brokerHostDefault);
     }
 
     /**
@@ -140,9 +144,11 @@ public class KnativeSettings {
      * @return
      */
     public static String getBrokerUrl() {
+        String brokerUrlDefault = YaksSettings.isOpenshiftCluster() ?
+                String.format("http://%s", getBrokerHost()) :
+                String.format("http://%s/${%s}/${%s}", getBrokerHost(), getNamespace(), KnativeVariableNames.BROKER_NAME.value());
         return System.getProperty(BROKER_URL_PROPERTY,
-                System.getenv(BROKER_URL_ENV) != null ? System.getenv(BROKER_URL_ENV) : String.format("http://%s/${%s}/${%s}",
-                        getBrokerHost(), getNamespace(), KnativeVariableNames.BROKER_NAME.value()));
+                System.getenv(BROKER_URL_ENV) != null ? System.getenv(BROKER_URL_ENV) : brokerUrlDefault);
     }
 
     /**

--- a/java/steps/yaks-knative/src/main/java/org/citrusframework/yaks/knative/KnativeSupport.java
+++ b/java/steps/yaks-knative/src/main/java/org/citrusframework/yaks/knative/KnativeSupport.java
@@ -98,21 +98,25 @@ public final class KnativeSupport {
         }
     }
 
-    public static CustomResourceDefinitionContext eventingCRDContext(String resourceName) {
-        return knativeCRDContext("eventing", resourceName);
+    public static CustomResourceDefinitionContext eventingCRDContext(String resourceName, String version) {
+        return knativeCRDContext("eventing", resourceName, version);
     }
 
-    public static CustomResourceDefinitionContext messagingCRDContext(String resourceName) {
-        return knativeCRDContext("messaging", resourceName);
+    public static CustomResourceDefinitionContext messagingCRDContext(String resourceName, String version) {
+        return knativeCRDContext("messaging", resourceName, version);
     }
 
-    public static CustomResourceDefinitionContext knativeCRDContext(String knativeComponent, String resourceName) {
+    public static CustomResourceDefinitionContext knativeCRDContext(String knativeComponent, String resourceName, String version) {
         return new CustomResourceDefinitionContext.Builder()
                 .withName(String.format("%s.%s.knative.dev", resourceName, knativeComponent))
                 .withGroup(String.format("%s.knative.dev", knativeComponent))
-                .withVersion("v1")
+                .withVersion(version)
                 .withPlural(resourceName)
                 .withScope("Namespaced")
                 .build();
+    }
+
+    public static String knativeApiVersion() {
+        return KnativeSettings.getApiVersion();
     }
 }

--- a/java/steps/yaks-knative/src/main/java/org/citrusframework/yaks/knative/actions/DeleteKnativeResourceAction.java
+++ b/java/steps/yaks-knative/src/main/java/org/citrusframework/yaks/knative/actions/DeleteKnativeResourceAction.java
@@ -40,7 +40,7 @@ public class DeleteKnativeResourceAction extends AbstractKnativeAction {
     @Override
     public void doExecute(TestContext context) {
         KnativeSupport.deleteResource(getKubernetesClient(), namespace(context),
-                KnativeSupport.knativeCRDContext(component, kind), resourceName);
+                KnativeSupport.knativeCRDContext(component, kind, KnativeSupport.knativeApiVersion()), resourceName);
     }
 
     /**

--- a/java/steps/yaks-knative/src/main/java/org/citrusframework/yaks/knative/actions/eventing/CreateBrokerAction.java
+++ b/java/steps/yaks-knative/src/main/java/org/citrusframework/yaks/knative/actions/eventing/CreateBrokerAction.java
@@ -40,7 +40,7 @@ public class CreateBrokerAction extends AbstractKnativeAction {
     @Override
     public void doExecute(TestContext context) {
         Broker broker = new BrokerBuilder()
-                .withApiVersion("eventing.knative.dev/v1")
+                .withApiVersion(String.format("eventing.knative.dev/%s", KnativeSupport.knativeApiVersion()))
                 .withNewMetadata()
                 .withNamespace(namespace(context))
                 .withName(context.replaceDynamicContentInString(brokerName))
@@ -49,7 +49,7 @@ public class CreateBrokerAction extends AbstractKnativeAction {
                 .build();
 
         KnativeSupport.createResource(getKubernetesClient(), namespace(context),
-                KnativeSupport.eventingCRDContext("brokers"), broker);
+                KnativeSupport.eventingCRDContext("brokers", KnativeSupport.knativeApiVersion()), broker);
     }
 
     /**

--- a/java/steps/yaks-knative/src/main/java/org/citrusframework/yaks/knative/actions/eventing/CreateTriggerAction.java
+++ b/java/steps/yaks-knative/src/main/java/org/citrusframework/yaks/knative/actions/eventing/CreateTriggerAction.java
@@ -57,7 +57,7 @@ public class CreateTriggerAction extends AbstractKnativeAction {
         addFilterOnAttributes(triggerSpec, context);
 
         TriggerBuilder triggerBuilder = new TriggerBuilder()
-                .withApiVersion("eventing.knative.dev/v1")
+                .withApiVersion(String.format("eventing.knative.dev/%s", KnativeSupport.knativeApiVersion()))
                 .withNewMetadata()
                     .withNamespace(namespace(context))
                     .withName(context.replaceDynamicContentInString(triggerName))
@@ -66,7 +66,7 @@ public class CreateTriggerAction extends AbstractKnativeAction {
                 .withSpec(triggerSpec.build());
 
         KnativeSupport.createResource(getKubernetesClient(), namespace(context),
-                KnativeSupport.eventingCRDContext("triggers"), triggerBuilder.build());
+                KnativeSupport.eventingCRDContext("triggers", KnativeSupport.knativeApiVersion()), triggerBuilder.build());
     }
 
     private void addFilterOnAttributes(TriggerSpecBuilder triggerSpec, TestContext context) {
@@ -81,7 +81,7 @@ public class CreateTriggerAction extends AbstractKnativeAction {
         if (channelName != null) {
             triggerSpec.withNewSubscriber()
                     .withNewRef()
-                        .withApiVersion("messaging.knative.dev/v1")
+                        .withApiVersion(String.format("messaging.knative.dev/%s", KnativeSupport.knativeApiVersion()))
                         .withKind("InMemoryChannel")
                         .withName(context.replaceDynamicContentInString(channelName))
                     .endRef()

--- a/java/steps/yaks-knative/src/main/java/org/citrusframework/yaks/knative/actions/eventing/VerifyBrokerAction.java
+++ b/java/steps/yaks-knative/src/main/java/org/citrusframework/yaks/knative/actions/eventing/VerifyBrokerAction.java
@@ -44,7 +44,7 @@ public class VerifyBrokerAction extends AbstractKnativeAction {
     public void doExecute(TestContext context) {
         try {
             Map<String, Object> resources = getKubernetesClient()
-                    .customResource(KnativeSupport.eventingCRDContext("brokers"))
+                    .customResource(KnativeSupport.eventingCRDContext("brokers", KnativeSupport.knativeApiVersion()))
                     .get(namespace(context), brokerName);
 
             Broker broker = KnativeSupport.json()

--- a/java/steps/yaks-knative/src/main/java/org/citrusframework/yaks/knative/actions/messaging/CreateChannelAction.java
+++ b/java/steps/yaks-knative/src/main/java/org/citrusframework/yaks/knative/actions/messaging/CreateChannelAction.java
@@ -40,7 +40,7 @@ public class CreateChannelAction extends AbstractKnativeAction {
     @Override
     public void doExecute(TestContext context) {
         Channel channel = new ChannelBuilder()
-            .withApiVersion("messaging.knative.dev/v1")
+            .withApiVersion(String.format("messaging.knative.dev/%s", KnativeSupport.knativeApiVersion()))
                 .withNewMetadata()
                     .withNamespace(namespace(context))
                     .withName(context.replaceDynamicContentInString(channelName))
@@ -49,7 +49,7 @@ public class CreateChannelAction extends AbstractKnativeAction {
             .build();
 
         KnativeSupport.createResource(getKubernetesClient(), namespace(context),
-                KnativeSupport.messagingCRDContext("channels"), channel);
+                KnativeSupport.messagingCRDContext("channels", KnativeSupport.knativeApiVersion()), channel);
     }
 
     /**

--- a/java/steps/yaks-knative/src/main/java/org/citrusframework/yaks/knative/actions/messaging/CreateSubscriptionAction.java
+++ b/java/steps/yaks-knative/src/main/java/org/citrusframework/yaks/knative/actions/messaging/CreateSubscriptionAction.java
@@ -45,7 +45,7 @@ public class CreateSubscriptionAction extends AbstractKnativeAction {
     @Override
     public void doExecute(TestContext context) {
         Subscription subscription = new SubscriptionBuilder()
-                .withApiVersion("messaging.knative.dev/v1")
+                .withApiVersion(String.format("messaging.knative.dev/%s", KnativeSupport.knativeApiVersion()))
                 .withNewMetadata()
                     .withNamespace(namespace(context))
                     .withName(context.replaceDynamicContentInString(subscriptionName))
@@ -53,7 +53,7 @@ public class CreateSubscriptionAction extends AbstractKnativeAction {
                 .endMetadata()
                 .withNewSpec()
                     .withChannel(new ObjectReferenceBuilder()
-                            .withApiVersion("messaging.knative.dev/v1")
+                            .withApiVersion(String.format("messaging.knative.dev/%s", KnativeSupport.knativeApiVersion()))
                             .withKind("InMemoryChannel")
                             .withName(context.replaceDynamicContentInString(channelName))
                             .build())
@@ -68,7 +68,7 @@ public class CreateSubscriptionAction extends AbstractKnativeAction {
                 .build();
 
         KnativeSupport.createResource(getKubernetesClient(), namespace(context),
-                KnativeSupport.messagingCRDContext("subscriptions"), subscription);
+                KnativeSupport.messagingCRDContext("subscriptions", KnativeSupport.knativeApiVersion()), subscription);
     }
 
     /**

--- a/java/steps/yaks-knative/src/main/java/org/citrusframework/yaks/knative/actions/serving/CreateServiceAction.java
+++ b/java/steps/yaks-knative/src/main/java/org/citrusframework/yaks/knative/actions/serving/CreateServiceAction.java
@@ -54,7 +54,7 @@ public class CreateServiceAction extends AbstractKnativeAction {
                 .endMetadata()
                 .withNewSpec()
                     // add selector to the very specific Pod that is running the test right now. This way the service will route all traffic to the test
-                    .withSelector(Collections.singletonMap("org.citrusframework.yaks/test-id", KnativeSettings.getTestId()))
+                    .withSelector(Collections.singletonMap("yaks.citrusframework.org/test-id", KnativeSettings.getTestId()))
                     .withPorts(new ServicePortBuilder()
                             .withProtocol(context.replaceDynamicContentInString(protocol))
                             .withPort(Integer.parseInt(context.replaceDynamicContentInString(port)))

--- a/java/steps/yaks-standard/src/main/java/org/citrusframework/yaks/YaksClusterType.java
+++ b/java/steps/yaks-standard/src/main/java/org/citrusframework/yaks/YaksClusterType.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.yaks;
+
+/**
+ * Cluster type determines where YAKS is being hosted on.
+ * @author Christoph Deppisch
+ */
+public enum YaksClusterType {
+
+    KUBERNETES,
+    OPENSHIFT
+}

--- a/java/steps/yaks-standard/src/main/java/org/citrusframework/yaks/YaksSettings.java
+++ b/java/steps/yaks-standard/src/main/java/org/citrusframework/yaks/YaksSettings.java
@@ -44,6 +44,10 @@ public class YaksSettings {
     private static final String NAMESPACE_ENV = YAKS_ENV_PREFIX + "NAMESPACE";
     private static final String NAMESPACE_DEFAULT = "default";
 
+    private static final String CLUSTER_TYPE_PROPERTY = YAKS_PROPERTY_PREFIX + "cluster.type";
+    private static final String CLUSTER_TYPE_ENV = YAKS_ENV_PREFIX + "CLUSTER_TYPE";
+    private static final String CLUSTER_TYPE_DEFAULT = YaksClusterType.KUBERNETES.name();
+
     /**
      * Namespace to work on when performing Kubernetes/Knative client operations on resources.
      * @return
@@ -74,5 +78,30 @@ public class YaksSettings {
     public static String getClusterWildcardDomain() {
         return System.getProperty(CLUSTER_WILDCARD_DOMAIN_PROPERTY,
                 System.getenv(CLUSTER_WILDCARD_DOMAIN_ENV) != null ? System.getenv(CLUSTER_WILDCARD_DOMAIN_ENV) : "default." + DEFAULT_DOMAIN_SUFFIX);
+    }
+
+    /**
+     * Cluster type that YAKS is running on.
+     * @return
+     */
+    public static YaksClusterType getClusterType() {
+        return YaksClusterType.valueOf(System.getProperty(CLUSTER_TYPE_PROPERTY,
+                System.getenv(CLUSTER_TYPE_ENV) != null ? System.getenv(CLUSTER_TYPE_ENV) : CLUSTER_TYPE_DEFAULT));
+    }
+
+    /**
+     * True when running on Openshift.
+     * @return
+     */
+    public static boolean isOpenshiftCluster() {
+        return YaksClusterType.OPENSHIFT.equals(getClusterType());
+    }
+
+    /**
+     * True when running on Kubernetes.
+     * @return
+     */
+    public static boolean isKubernetesCluster() {
+        return YaksClusterType.KUBERNETES.equals(getClusterType());
     }
 }

--- a/pkg/controller/test/start.go
+++ b/pkg/controller/test/start.go
@@ -19,6 +19,7 @@ package test
 
 import (
 	"context"
+	"github.com/citrusframework/yaks/pkg/util/openshift"
 	"strings"
 
 	"github.com/citrusframework/yaks/pkg/apis/yaks/v1alpha1"
@@ -166,6 +167,18 @@ func (action *startAction) newTestingPod(ctx context.Context, test *v1alpha1.Tes
 			Value: "/etc/yaks/tests/" + test.Spec.Settings.Name,
 		})
 	}
+
+	var clusterType v1alpha1.ClusterType
+	if isOpenshift, err := openshift.IsOpenShift(action.client); err == nil && isOpenshift {
+		clusterType = v1alpha1.ClusterTypeOpenShift
+	} else {
+		clusterType = v1alpha1.ClusterTypeKubernetes
+	}
+
+	pod.Spec.Containers[0].Env = append(pod.Spec.Containers[0].Env, v1.EnvVar{
+		Name:  "YAKS_CLUSTER_TYPE",
+		Value: strings.ToUpper(string(clusterType)),
+	})
 
 	pod.Spec.Containers[0].Env = append(pod.Spec.Containers[0].Env, v1.EnvVar{
 		Name:  "YAKS_TEST_NAME",


### PR DESCRIPTION
- Users can set the API version of Knative as environment setting
- Event consumer service selector was using the wrong YAKS domain
- Inject cluster type to YAKS runtime and use different default broker name and url when running on Openshift and Kubernetes respectively