### PR TITLE
fix(#123): Use secrets for sensitive data

### DIFF
--- a/examples/secrets/credentials.properties
+++ b/examples/secrets/credentials.properties
@@ -15,8 +15,5 @@
 # limitations under the License.
 #
 
-citrus.default.message.type=JSON
-
-# Spring bean auto configuration
-citrus.spring.java.config=org.citrusframework.yaks.YaksAutoConfiguration
-
+user=admin
+password=secret

--- a/examples/secrets/delete-secret.sh
+++ b/examples/secrets/delete-secret.sh
@@ -1,22 +1,19 @@
-#
+#!/bin/sh
+
 # Licensed to the Apache Software Foundation (ASF) under one or more
-# contributor license agreements. See the NOTICE file distributed with
+# contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.
 # The ASF licenses this file to You under the Apache License, Version 2.0
 # (the "License"); you may not use this file except in compliance with
 # the License.  You may obtain a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
 
-citrus.default.message.type=JSON
-
-# Spring bean auto configuration
-citrus.spring.java.config=org.citrusframework.yaks.YaksAutoConfiguration
-
+# delete secret
+kubectl delete secret my-secret

--- a/examples/secrets/prepare-secret.sh
+++ b/examples/secrets/prepare-secret.sh
@@ -1,22 +1,22 @@
-#
+#!/bin/sh
+
 # Licensed to the Apache Software Foundation (ASF) under one or more
-# contributor license agreements. See the NOTICE file distributed with
+# contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.
 # The ASF licenses this file to You under the Apache License, Version 2.0
 # (the "License"); you may not use this file except in compliance with
 # the License.  You may obtain a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
 
-citrus.default.message.type=JSON
+# create secret from properties file
+kubectl create secret generic my-secret --from-file=credentials.properties
 
-# Spring bean auto configuration
-citrus.spring.java.config=org.citrusframework.yaks.YaksAutoConfiguration
-
+# bind secret to test by name
+kubectl label secret my-secret yaks.citrusframework.org/test=use-secrets

--- a/examples/secrets/use-secrets.feature
+++ b/examples/secrets/use-secrets.feature
@@ -1,0 +1,5 @@
+Feature: Secrets
+
+  Scenario: Print message
+    Given print 'This variable ${user} should be coming from a secret volume mount'
+    Given print 'This variable ${password} should be coming from a secret volume mount'

--- a/examples/secrets/yaks-config.yaml
+++ b/examples/secrets/yaks-config.yaml
@@ -1,6 +1,6 @@
-#
+# ---------------------------------------------------------------------------
 # Licensed to the Apache Software Foundation (ASF) under one or more
-# contributor license agreements. See the NOTICE file distributed with
+# contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.
 # The ASF licenses this file to You under the Apache License, Version 2.0
 # (the "License"); you may not use this file except in compliance with
@@ -13,10 +13,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
+# ---------------------------------------------------------------------------
 
-citrus.default.message.type=JSON
-
-# Spring bean auto configuration
-citrus.spring.java.config=org.citrusframework.yaks.YaksAutoConfiguration
-
+pre:
+  - script: prepare-secret.sh
+post:
+  - script: delete-secret.sh

--- a/java/runtime/yaks-runtime-maven/src/test/java/org/citrusframework/yaks/YaksAutoConfiguration.java
+++ b/java/runtime/yaks-runtime-maven/src/test/java/org/citrusframework/yaks/YaksAutoConfiguration.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.yaks;
+
+import java.io.File;
+import java.net.URL;
+import java.util.stream.Stream;
+
+import com.consol.citrus.variable.GlobalVariables;
+import com.consol.citrus.variable.GlobalVariablesPropertyLoader;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * @author Christoph Deppisch
+ */
+@Configuration
+public class YaksAutoConfiguration {
+
+    @Bean
+    public GlobalVariables globalVariables() {
+        return new GlobalVariables();
+    }
+
+    @Bean
+    public GlobalVariablesPropertyLoader globalVariablesPropertyLoader() {
+        GlobalVariablesPropertyLoader propertyLoader = new GlobalVariablesPropertyLoader();
+
+        // Load mounted secrets as global variables
+        URL mountedSecrets = Thread.currentThread().getContextClassLoader().getResource("secrets");
+        if (mountedSecrets != null) {
+            File secretsDir = new File(mountedSecrets.getPath());
+            if (secretsDir.exists() && secretsDir.isDirectory()) {
+                File[] propertyFiles = secretsDir.listFiles();
+                if (propertyFiles != null) {
+                    Stream.of(propertyFiles).forEach(file -> {
+                        propertyLoader.getPropertyFiles().add("file:" + file.getPath());
+                    });
+                }
+            }
+        }
+
+        return propertyLoader;
+    }
+}

--- a/java/tools/maven/yaks-maven-extension/src/main/java/org/citrusframework/yaks/maven/extension/ExtensionSettings.java
+++ b/java/tools/maven/yaks-maven-extension/src/main/java/org/citrusframework/yaks/maven/extension/ExtensionSettings.java
@@ -27,6 +27,9 @@ public final class ExtensionSettings {
     public static final String TESTS_PATH_KEY = "yaks.tests.path";
     public static final String TESTS_PATH_ENV = "YAKS_TESTS_PATH";
 
+    public static final String SECRETS_PATH_KEY = "yaks.secrets.path";
+    public static final String SECRETS_PATH_ENV = "YAKS_SECRETS_PATH";
+
     public static final String SETTINGS_FILE_DEFAULT = "classpath:yaks.properties";
     public static final String SETTINGS_FILE_KEY = "yaks.settings.file";
     public static final String SETTINGS_FILE_ENV = "YAKS_SETTINGS_FILE";
@@ -58,11 +61,28 @@ public final class ExtensionSettings {
     }
 
     /**
+     * Gets the external secrets path mount. Usually added to the runtime image via volume mount using K8s secrets.
+     * @return
+     */
+    public static String getMountedSecretsPath() {
+        return System.getProperty(ExtensionSettings.SECRETS_PATH_KEY, System.getenv(ExtensionSettings.SECRETS_PATH_ENV) != null ?
+                System.getenv(ExtensionSettings.SECRETS_PATH_ENV) : "");
+    }
+
+    /**
      * Checks for mounted tests path setting.
      * @return
      */
     public static boolean hasMountedTests() {
         return getMountedTestsPath().length() > 0;
+    }
+
+    /**
+     * Checks for mounted secrets path setting.
+     * @return
+     */
+    public static boolean hasMountedSecrets() {
+        return getMountedSecretsPath().length() > 0;
     }
 
     /**

--- a/java/tools/maven/yaks-maven-extension/src/main/java/org/citrusframework/yaks/maven/extension/ProjectModelEnricher.java
+++ b/java/tools/maven/yaks-maven-extension/src/main/java/org/citrusframework/yaks/maven/extension/ProjectModelEnricher.java
@@ -63,6 +63,7 @@ public class ProjectModelEnricher implements ProjectExecutionListener {
         Model projectModel = projectExecutionEvent.getProject().getModel();
         injectProjectDependencies(projectModel);
         injectTestResources(projectModel);
+        injectSecrets(projectModel);
         loadLoggingConfiguration(projectExecutionEvent.getProject());
     }
 
@@ -80,6 +81,23 @@ public class ProjectModelEnricher implements ProjectExecutionListener {
             projectModel.getBuild().getTestResources().add(mountedTests);
 
             logger.info("Add mounted test resources in directory: " + ExtensionSettings.getMountedTestsPath());
+        }
+    }
+
+    /**
+     * Dynamically add test resource directory pointing to mounted secrets directory. Mounted directory usually gets added
+     * as volume mount and holds property files holding secrets to load in this project.
+     * @param projectModel
+     */
+    private void injectSecrets(Model projectModel) {
+        if (ExtensionSettings.hasMountedSecrets()) {
+            Resource mountedSecrets = new Resource();
+            mountedSecrets.setDirectory(ExtensionSettings.getMountedSecretsPath() + "/..data");
+            mountedSecrets.setTargetPath(projectModel.getBuild().getTestOutputDirectory() + "/secrets");
+            mountedSecrets.setFiltering(false);
+            projectModel.getBuild().getTestResources().add(mountedSecrets);
+
+            logger.info("Add mounted secret resources in directory: " + ExtensionSettings.getMountedSecretsPath());
         }
     }
 

--- a/pkg/apis/yaks/v1alpha1/test_types.go
+++ b/pkg/apis/yaks/v1alpha1/test_types.go
@@ -46,6 +46,7 @@ type TestSpec struct {
 	Source   SourceSpec   `json:"source,omitempty"`
 	Settings SettingsSpec `json:"config,omitempty"`
 	Env      []string     `json:"env,omitempty"`
+	Secret   string       `json:"secret,omitempty"`
 }
 
 // SourceSpec--

--- a/pkg/cmd/config/config.go
+++ b/pkg/cmd/config/config.go
@@ -49,6 +49,7 @@ type RuntimeConfig struct {
 	Cucumber CucumberConfig
 	Settings SettingsConfig
 	Env 	 []EnvConfig
+	Secret   string
 }
 
 type CucumberConfig struct {

--- a/pkg/cmd/test.go
+++ b/pkg/cmd/test.go
@@ -387,6 +387,10 @@ func (o *testCmdOptions) createAndRunTest(c client.Client, rawName string, runCo
 		return nil, err
 	}
 
+	if runConfig.Config.Runtime.Secret != "" {
+		test.Spec.Secret = runConfig.Config.Runtime.Secret;
+	}
+
 	switch o.DumpFormat {
 		case "":
 			// continue..

--- a/script/package_maven_artifacts.sh
+++ b/script/package_maven_artifacts.sh
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+set -e
+
 location=$(dirname $0)
 
 cd ${location}/../java
@@ -35,7 +37,9 @@ cp -r runtime/yaks-runtime-maven $PWD/../build/_maven_project
 # fresh build YAKS java modules
 echo Build YAKS modules ...
 
-./mvnw clean install $@
+./mvnw \
+    clean \
+    install $@
 
 # install YAKS Maven extension to runtime project in image
 echo Install YAKS Maven extension
@@ -57,6 +61,7 @@ echo Copy project dependencies ...
 echo Install YAKS artifacts ...
 
 ./mvnw \
+    --quiet \
     -DskipTests \
     -Dmaven.repo.local=$PWD/../build/_maven_repository \
     jar:jar \


### PR DESCRIPTION
Fixes #123 

Users can add secrets and bind those to tests and named configuration. Tests can use the secret properties as normal test variables. The operator automatically picks up the secrets bound to a test and mounts those as volumes.