### PR TITLE
fix(#148): Add KameletBinding support

### DIFF
--- a/examples/kamelets/kamelet-binding.feature
+++ b/examples/kamelets/kamelet-binding.feature
@@ -10,7 +10,9 @@ Feature: Kamelet resource
     Given load Kamelet timer-source.kamelet.yaml
     Then Kamelet timer-source should be available
 
-  Scenario: Use Kamelet
-    Given load Camel-K integration timer-to-log.groovy
-    Then Camel-K integration timer-to-log should be running
-    Then Camel-K integration timer-to-log should print Hello Kamelets
+  Scenario: Bind Kamelet to URI
+    Given KameletBinding source properties
+      | message  | Hello World |
+    And bind Kamelet timer-source to uri https://greeting-service.svc.cluster.local
+    When create KameletBinding timer-source-uri
+    Then KameletBinding timer-source-uri should be available

--- a/examples/kamelets/kamelet-kafka-binding.yaml
+++ b/examples/kamelets/kamelet-kafka-binding.yaml
@@ -1,0 +1,34 @@
+# ---------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ---------------------------------------------------------------------------
+
+apiVersion: camel.apache.org/v1alpha1
+kind: KameletBinding
+metadata:
+  name: timer-source-kafka
+spec:
+  source:
+    ref:
+      kind: Kamelet
+      apiVersion: camel.apache.org/v1alpha1
+      name: timer-source
+    properties:
+      message: "Hello world!"
+  sink:
+    ref:
+      kind: KafkaTopic
+      apiVersion: kafka.strimzi.io/v1beta1
+      name: hello-topic

--- a/examples/kamelets/kamelet-knative-binding.yaml
+++ b/examples/kamelets/kamelet-knative-binding.yaml
@@ -1,0 +1,34 @@
+# ---------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ---------------------------------------------------------------------------
+
+apiVersion: camel.apache.org/v1alpha1
+kind: KameletBinding
+metadata:
+  name: timer-source-knative
+spec:
+  source:
+    ref:
+      kind: Kamelet
+      apiVersion: camel.apache.org/v1alpha1
+      name: timer-source
+    properties:
+      message: "Hello world!"
+  sink:
+    ref:
+      kind: InMemoryChannel
+      apiVersion: messaging.knative.dev/v1beta1
+      name: messages

--- a/examples/kamelets/kamelet-uri-binding.yaml
+++ b/examples/kamelets/kamelet-uri-binding.yaml
@@ -1,0 +1,31 @@
+# ---------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ---------------------------------------------------------------------------
+
+apiVersion: camel.apache.org/v1alpha1
+kind: KameletBinding
+metadata:
+  name: timer-source-uri
+spec:
+  source:
+    ref:
+      kind: Kamelet
+      apiVersion: camel.apache.org/v1alpha1
+      name: timer-source
+    properties:
+      message: "Hello world!"
+  sink:
+    uri: http://${host}:${port}

--- a/examples/kamelets/kamelet.feature
+++ b/examples/kamelets/kamelet.feature
@@ -4,7 +4,7 @@ Feature: Kamelet
     Given Disable auto removal of Kamelet resources
     Given Camel-K resource polling configuration
       | maxAttempts          | 20   |
-      | delayBetweemAttempts | 1000 |
+      | delayBetweenAttempts | 1000 |
 
   Scenario: Create Kamelet
     Given Kamelet property definition

--- a/examples/kamelets/timer-source.kamelet.yaml
+++ b/examples/kamelets/timer-source.kamelet.yaml
@@ -50,5 +50,5 @@ spec:
         period: "#property:period"
       steps:
         - set-body:
-            constant: "#property:message"
+            constant: "{{message}}"
         - to: "kamelet:sink"

--- a/java/steps/yaks-camel-k/pom.xml
+++ b/java/steps/yaks-camel-k/pom.xml
@@ -35,6 +35,18 @@
       <version>${project.version}</version>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.citrusframework.yaks</groupId>
+      <artifactId>yaks-kafka</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.citrusframework.yaks</groupId>
+      <artifactId>yaks-knative</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
 
     <dependency>
       <groupId>io.cucumber</groupId>

--- a/java/steps/yaks-camel-k/src/main/java/org/citrusframework/yaks/camelk/KameletSteps.java
+++ b/java/steps/yaks-camel-k/src/main/java/org/citrusframework/yaks/camelk/KameletSteps.java
@@ -17,6 +17,7 @@
 
 package org.citrusframework.yaks.camelk;
 
+import java.util.HashMap;
 import java.util.Map;
 
 import com.consol.citrus.Citrus;
@@ -30,7 +31,11 @@ import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import org.citrusframework.yaks.camelk.model.Kamelet;
+import org.citrusframework.yaks.camelk.model.KameletBinding;
+import org.citrusframework.yaks.camelk.model.KameletBindingSpec;
 import org.citrusframework.yaks.camelk.model.KameletSpec;
+import org.citrusframework.yaks.kafka.KafkaSettings;
+import org.citrusframework.yaks.knative.KnativeSettings;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.Resource;
 import org.springframework.util.StringUtils;
@@ -49,8 +54,17 @@ public class KameletSteps {
 
     private KubernetesClient k8sClient;
 
-    private Kamelet.Builder builder;
+    // Kamelet builder
+    private Kamelet.Builder kamelet;
     private KameletSpec.Definition definition;
+
+    // KameleteBinding builder
+    private KameletBinding.Builder binding;
+    private KameletBindingSpec.Endpoint source;
+    private KameletBindingSpec.Endpoint sink;
+
+    private Map<String, Object> sourceProperties;
+    private Map<String, Object> sinkProperties;
 
     private boolean autoRemoveResources = CamelKSettings.isAutoRemoveResources();
 
@@ -60,8 +74,8 @@ public class KameletSteps {
             k8sClient = CamelKSupport.getKubernetesClient(citrus);
         }
 
-        builder = new Kamelet.Builder();
-        definition = new KameletSpec.Definition();
+        initializeKameletBuilder();
+        initializeKameletBindingBuilder();
     }
 
     @Given("^Disable auto removal of Kamelet resources$")
@@ -76,7 +90,7 @@ public class KameletSteps {
 
 	@Given("^Kamelet type (in|out|error)(?:=| is )\"(.+)\"$")
 	public void addType(String slot, String mediaType) {
-        builder.addType(slot, mediaType);
+        kamelet.addType(slot, mediaType);
 	}
 
     @Given("^Kamelet title \"(.+)\"$")
@@ -86,12 +100,12 @@ public class KameletSteps {
 
     @Given("^Kamelet source ([a-z0-9-]+).([a-z0-9-]+)$")
 	public void setSource(String name, String language, String content) {
-        builder.source(name, language, content);
+        kamelet.source(name, language, content);
 	}
 
     @Given("^Kamelet flow$")
 	public void setFlow(String flow) {
-        builder.flow(flow);
+        kamelet.flow(flow);
 	}
 
     @Given("^Kamelet property definition$")
@@ -116,6 +130,52 @@ public class KameletSteps {
                 new KameletSpec.Definition.PropertyConfig(title, type, defaultValue, example));
 	}
 
+	@Given("^KameletBinding source properties$")
+    public void setKameletBindingSourceProperties(Map<String, Object> properties) {
+        this.sourceProperties.putAll(properties);
+    }
+
+    @Given("^KameletBinding sink properties$")
+    public void setKameletBindingSinkProperties(Map<String, Object> properties) {
+        this.sinkProperties.putAll(properties);
+    }
+
+    @Given("^bind Kamelet ([a-z0-9-]+) to uri ([^\\s]+)$")
+    public void bindKameletToUri(String kameletName, String uri) {
+        KameletBindingSpec.Endpoint.ObjectReference sourceRef =
+                new KameletBindingSpec.Endpoint.ObjectReference(kameletName, "Kamelet", CamelKSettings.getNamespace());
+        source = new KameletBindingSpec.Endpoint(sourceRef);
+
+        sink = new KameletBindingSpec.Endpoint(uri);
+    }
+
+    @Given("^bind Kamelet ([a-z0-9-]+) to Kafka topic ([^\\s]+)$")
+    public void bindKameletToKafka(String kameletName, String topic) {
+        KameletBindingSpec.Endpoint.ObjectReference sourceRef =
+                new KameletBindingSpec.Endpoint.ObjectReference(kameletName, "Kamelet", CamelKSettings.getNamespace());
+        source = new KameletBindingSpec.Endpoint(sourceRef);
+
+        KameletBindingSpec.Endpoint.ObjectReference sinkRef =
+                new KameletBindingSpec.Endpoint.ObjectReference(topic, "KafkaTopic", KafkaSettings.getNamespace());
+        sink = new KameletBindingSpec.Endpoint(sinkRef);
+    }
+
+    @Given("^bind Kamelet ([a-z0-9-]+) to Knative channel ([^\\s]+)$")
+    public void bindKameletToKnativeChannel(String kameletName, String channel) {
+        bindKameletToKnativeChannel(kameletName, channel, "InMemoryChannel");
+    }
+
+    @Given("^bind Kamelet ([a-z0-9-]+) to Knative channel ([^\\s]+) of kind ([^\\s]+)$")
+    public void bindKameletToKnativeChannel(String kameletName, String channel, String channelKind) {
+        KameletBindingSpec.Endpoint.ObjectReference sourceRef =
+                new KameletBindingSpec.Endpoint.ObjectReference(kameletName, "Kamelet", CamelKSettings.getNamespace());
+        source = new KameletBindingSpec.Endpoint(sourceRef);
+
+        KameletBindingSpec.Endpoint.ObjectReference sinkRef =
+                new KameletBindingSpec.Endpoint.ObjectReference(channel, channelKind, KnativeSettings.getNamespace());
+        sink = new KameletBindingSpec.Endpoint(sinkRef);
+    }
+
     @Given("^load Kamelet ([a-z0-9-]+).kamelet.yaml$")
     public void loadKameletFromFile(String fileName) {
         Resource resource = new ClassPathResource(fileName + ".kamelet.yaml");
@@ -130,22 +190,36 @@ public class KameletSteps {
         }
     }
 
+    @Given("^load KameletBinding ([a-z0-9-]+).yaml$")
+    public void loadKameletBindingFromFile(String fileName) {
+        Resource resource = new ClassPathResource(fileName + ".yaml");
+        runner.run(camelk()
+                .client(k8sClient)
+                .createKameletBinding(fileName)
+                .resource(resource));
+
+        if (autoRemoveResources) {
+            runner.then(doFinally()
+                    .actions(camelk().client(k8sClient).deleteKameletBinding(fileName)));
+        }
+    }
+
     @Given("^create Kamelet ([a-z0-9-]+)$")
 	public void createNewKamelet(String name) {
-        builder.name(name);
+        kamelet.name(name);
 
         if (definition.getTitle() == null || definition.getTitle().isEmpty()) {
             definition.setTitle(StringUtils.capitalize(name));
         }
 
-        builder.definition(definition);
+        kamelet.definition(definition);
 
         runner.run(camelk()
                     .client(k8sClient)
                     .createKamelet(name)
-                    .fromBuilder(builder));
+                    .fromBuilder(kamelet));
 
-        builder = new Kamelet.Builder();
+        initializeKameletBuilder();
 
         if (autoRemoveResources) {
             runner.then(doFinally()
@@ -155,9 +229,32 @@ public class KameletSteps {
 
 	@Given("^create Kamelet ([a-z0-9-]+) with flow$")
 	public void createNewKameletWithFlow(String name, String flow) {
-        builder.flow(flow);
+        kamelet.flow(flow);
         createNewKamelet(name);
 	}
+
+    @Given("^create KameletBinding ([a-z0-9-]+)$")
+    public void createNewKameletBinding(String name) {
+        binding.name(name);
+
+        source.getProperties().putAll(sourceProperties);
+        sink.getProperties().putAll(sinkProperties);
+
+        binding.source(source);
+        binding.source(sink);
+
+        runner.run(camelk()
+                .client(k8sClient)
+                .createKameletBinding(name)
+                .fromBuilder(binding));
+
+        initializeKameletBindingBuilder();
+
+        if (autoRemoveResources) {
+            runner.then(doFinally()
+                    .actions(camelk().client(k8sClient).deleteKameletBinding(name)));
+        }
+    }
 
     @Given("^remove Kamelet$")
 	public void deleteKamelet(String name) {
@@ -166,12 +263,41 @@ public class KameletSteps {
                     .deleteKamelet(name));
 	}
 
+    @Given("^remove KameletBinding$")
+	public void deleteKameletBinding(String name) {
+        runner.run(camelk()
+                    .client(k8sClient)
+                    .deleteKameletBinding(name));
+	}
+
     @Given("^Kamelet ([a-z0-9-]+) is available$")
     @Then("^Kamelet ([a-z0-9-]+) should be available$")
-    public void shouldBeAvailable(String name) {
+    public void kameletShouldBeAvailable(String name) {
         runner.run(camelk()
                 .client(k8sClient)
                 .verifyKamelet(name)
                 .isAvailable());
+    }
+
+    @Given("^KameletBinding ([a-z0-9-]+) is available$")
+    @Then("^KameletBinding ([a-z0-9-]+) should be available$")
+    public void kameletBindingShouldBeAvailable(String name) {
+        runner.run(camelk()
+                .client(k8sClient)
+                .verifyKameletBinding(name)
+                .isAvailable());
+    }
+
+    private void initializeKameletBuilder() {
+        kamelet = new Kamelet.Builder();
+        definition = new KameletSpec.Definition();
+    }
+
+    private void initializeKameletBindingBuilder() {
+        binding = new KameletBinding.Builder();
+        source = null;
+        sink = null;
+        sourceProperties = new HashMap<>();
+        sinkProperties = new HashMap<>();
     }
 }

--- a/java/steps/yaks-camel-k/src/main/java/org/citrusframework/yaks/camelk/actions/CamelKActionBuilder.java
+++ b/java/steps/yaks-camel-k/src/main/java/org/citrusframework/yaks/camelk/actions/CamelKActionBuilder.java
@@ -23,8 +23,11 @@ import org.citrusframework.yaks.camelk.actions.integration.CreateIntegrationActi
 import org.citrusframework.yaks.camelk.actions.integration.DeleteIntegrationAction;
 import org.citrusframework.yaks.camelk.actions.integration.VerifyIntegrationAction;
 import org.citrusframework.yaks.camelk.actions.kamelet.CreateKameletAction;
+import org.citrusframework.yaks.camelk.actions.kamelet.CreateKameletBindingAction;
 import org.citrusframework.yaks.camelk.actions.kamelet.DeleteKameletAction;
+import org.citrusframework.yaks.camelk.actions.kamelet.DeleteKameletBindingAction;
 import org.citrusframework.yaks.camelk.actions.kamelet.VerifyKameletAction;
+import org.citrusframework.yaks.camelk.actions.kamelet.VerifyKameletBindingAction;
 import org.springframework.util.Assert;
 
 /**
@@ -102,6 +105,30 @@ public class CamelKActionBuilder implements TestActionBuilder.DelegatingTestActi
     }
 
     /**
+     * Create KameletBinding CRD in current namespace.
+     * @param bindingName the name of the KameletBinding.
+     */
+    public CreateKameletBindingAction.Builder createKameletBinding(String bindingName) {
+        CreateKameletBindingAction.Builder builder = new CreateKameletBindingAction.Builder()
+                .client(kubernetesClient)
+                .binding(bindingName);
+        this.delegate = builder;
+        return builder;
+    }
+
+    /**
+     * Delete KameletBinding CRD from current namespace.
+     * @param bindingName the name of the KameletBinding.
+     */
+    public DeleteKameletBindingAction.Builder deleteKameletBinding(String bindingName) {
+        DeleteKameletBindingAction.Builder builder = new DeleteKameletBindingAction.Builder()
+                .client(kubernetesClient)
+                .binding(bindingName);
+        this.delegate = builder;
+        return builder;
+    }
+
+    /**
      * Verify that given integration is running.
      * @param integrationName the name of the Camel-K integration.
      */
@@ -121,6 +148,18 @@ public class CamelKActionBuilder implements TestActionBuilder.DelegatingTestActi
         VerifyKameletAction.Builder builder = new VerifyKameletAction.Builder()
                 .client(kubernetesClient)
                 .isAvailable(kameletName);
+        this.delegate = builder;
+        return builder;
+    }
+
+    /**
+     * Verify that given KameletBinding CRD is available in current namespace.
+     * @param bindingName the name of the KameletBinding.
+     */
+    public VerifyKameletBindingAction.Builder verifyKameletBinding(String bindingName) {
+        VerifyKameletBindingAction.Builder builder = new VerifyKameletBindingAction.Builder()
+                .client(kubernetesClient)
+                .isAvailable(bindingName);
         this.delegate = builder;
         return builder;
     }

--- a/java/steps/yaks-camel-k/src/main/java/org/citrusframework/yaks/camelk/actions/kamelet/CreateKameletBindingAction.java
+++ b/java/steps/yaks-camel-k/src/main/java/org/citrusframework/yaks/camelk/actions/kamelet/CreateKameletBindingAction.java
@@ -1,0 +1,192 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.yaks.camelk.actions.kamelet;
+
+import java.io.IOException;
+import java.util.Map;
+
+import com.consol.citrus.context.TestContext;
+import com.consol.citrus.exceptions.CitrusRuntimeException;
+import com.consol.citrus.util.FileUtils;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import io.fabric8.kubernetes.client.dsl.base.CustomResourceDefinitionContext;
+import org.citrusframework.yaks.camelk.CamelKSettings;
+import org.citrusframework.yaks.camelk.CamelKSupport;
+import org.citrusframework.yaks.camelk.actions.AbstractCamelKAction;
+import org.citrusframework.yaks.camelk.model.DoneableKameletBinding;
+import org.citrusframework.yaks.camelk.model.Integration;
+import org.citrusframework.yaks.camelk.model.KameletBinding;
+import org.citrusframework.yaks.camelk.model.KameletBindingList;
+import org.citrusframework.yaks.camelk.model.KameletBindingSpec;
+import org.springframework.core.io.Resource;
+
+/**
+ * Test action creates new Camel-K integration with given name and source code. Uses given Kubernetes client to
+ * create a custom resource of type integration.
+ *
+ * @author Christoph Deppisch
+ */
+public class CreateKameletBindingAction extends AbstractCamelKAction {
+
+    private final String name;
+    private final Integration integration;
+    private final KameletBindingSpec.Endpoint source;
+    private final KameletBindingSpec.Endpoint sink;
+    private final Resource resource;
+
+    /**
+     * Constructor using given builder.
+     * @param builder
+     */
+    public CreateKameletBindingAction(Builder builder) {
+        super("create-kamelet-binding", builder);
+        this.name = builder.name;
+        this.integration = builder.integration;
+        this.source = builder.source;
+        this.sink = builder.sink;
+        this.resource = builder.resource;
+    }
+
+    @Override
+    public void doExecute(TestContext context) {
+        createKameletBinding(context);
+    }
+
+    private void createKameletBinding(TestContext context) {
+        final KameletBinding binding;
+
+        if (resource != null) {
+            try {
+                binding = CamelKSupport.yaml().loadAs(FileUtils.readToString(resource), KameletBinding.class);
+            } catch (IOException e) {
+                throw new CitrusRuntimeException(String.format("Failed to load KameletBinding from resource %s", name + ".kamelet.yaml"));
+            }
+        } else {
+            final KameletBinding.Builder builder = new KameletBinding.Builder()
+                    .name(context.replaceDynamicContentInString(name));
+
+            if (integration != null) {
+                builder.integration(integration);
+            }
+
+            if (source != null) {
+                builder.source(source);
+            }
+
+            if (sink != null) {
+                builder.sink(sink);
+            }
+
+            binding = builder.build();
+        }
+
+        if (LOG.isDebugEnabled()) {
+            try {
+                LOG.debug(CamelKSupport.json().writeValueAsString(binding));
+            } catch (JsonProcessingException e) {
+                LOG.warn("Unable to dump KameletBinding data", e);
+            }
+        }
+
+        CustomResourceDefinitionContext ctx = CamelKSupport.kameletCRDContext(CamelKSettings.getKameletApiVersion());
+        getKubernetesClient().customResources(ctx, KameletBinding.class, KameletBindingList.class, DoneableKameletBinding.class)
+                .inNamespace(CamelKSettings.getNamespace())
+                .createOrReplace(binding);
+
+        LOG.info(String.format("Successfully created KameletBinding '%s'", binding.getMetadata().getName()));
+    }
+
+    /**
+     * Action builder.
+     */
+    public static final class Builder extends AbstractCamelKAction.Builder<CreateKameletBindingAction, Builder> {
+
+        private String name;
+        private Integration integration;
+        private KameletBindingSpec.Endpoint source;
+        private KameletBindingSpec.Endpoint sink;
+        private Resource resource;
+
+        public Builder binding(String kameletName) {
+            this.name = kameletName;
+            return this;
+        }
+
+        public Builder integration(Integration integration) {
+            this.integration = integration;
+            return this;
+        }
+
+        public Builder source(KameletBindingSpec.Endpoint source) {
+            this.source = source;
+            return this;
+        }
+
+        public Builder source(String uri) {
+            return source(new KameletBindingSpec.Endpoint(uri));
+        }
+
+        public Builder source(KameletBindingSpec.Endpoint.ObjectReference ref, String properties) {
+            Map<String, Object> props = null;
+            if (properties != null && !properties.isEmpty()) {
+                props = CamelKSupport.yaml().load(properties);
+            }
+
+            return source(new KameletBindingSpec.Endpoint(ref, props));
+        }
+
+        public Builder sink(KameletBindingSpec.Endpoint sink) {
+            this.sink = sink;
+            return this;
+        }
+
+        public Builder sink(String uri) {
+            return sink(new KameletBindingSpec.Endpoint(uri));
+        }
+
+        public Builder sink(KameletBindingSpec.Endpoint.ObjectReference ref, String properties) {
+            Map<String, Object> props = null;
+            if (properties != null && !properties.isEmpty()) {
+                props = CamelKSupport.yaml().load(properties);
+            }
+
+            return sink(new KameletBindingSpec.Endpoint(ref, props));
+        }
+
+        public Builder fromBuilder(KameletBinding.Builder builder) {
+            KameletBinding binding = builder.build();
+
+            name = binding.getMetadata().getName();
+            integration = binding.getSpec().getIntegration();
+            source = binding.getSpec().getSource();
+            sink = binding.getSpec().getSink();
+
+            return this;
+        }
+
+        public Builder resource(Resource resource) {
+            this.resource = resource;
+            return this;
+        }
+
+        @Override
+        public CreateKameletBindingAction build() {
+            return new CreateKameletBindingAction(this);
+        }
+    }
+}

--- a/java/steps/yaks-camel-k/src/main/java/org/citrusframework/yaks/camelk/actions/kamelet/DeleteKameletBindingAction.java
+++ b/java/steps/yaks-camel-k/src/main/java/org/citrusframework/yaks/camelk/actions/kamelet/DeleteKameletBindingAction.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.yaks.camelk.actions.kamelet;
+
+import com.consol.citrus.context.TestContext;
+import io.fabric8.kubernetes.client.dsl.base.CustomResourceDefinitionContext;
+import org.citrusframework.yaks.camelk.CamelKSettings;
+import org.citrusframework.yaks.camelk.CamelKSupport;
+import org.citrusframework.yaks.camelk.actions.AbstractCamelKAction;
+import org.citrusframework.yaks.camelk.model.DoneableKameletBinding;
+import org.citrusframework.yaks.camelk.model.KameletBinding;
+import org.citrusframework.yaks.camelk.model.KameletBindingList;
+
+/**
+ * @author Christoph Deppisch
+ */
+public class DeleteKameletBindingAction extends AbstractCamelKAction {
+
+    private final String name;
+
+    public DeleteKameletBindingAction(Builder builder) {
+        super("delete-kamelet-binding", builder);
+
+        this.name = builder.name;
+    }
+
+    @Override
+    public void doExecute(TestContext context) {
+        String bindingName = context.replaceDynamicContentInString(name);
+        CustomResourceDefinitionContext ctx = CamelKSupport.kameletCRDContext(CamelKSettings.getKameletApiVersion());
+        getKubernetesClient().customResources(ctx, KameletBinding.class, KameletBindingList.class, DoneableKameletBinding.class)
+                .inNamespace(CamelKSettings.getNamespace())
+                .withName(bindingName)
+                .delete();
+    }
+
+    /**
+     * Action builder.
+     */
+    public static class Builder extends AbstractCamelKAction.Builder<DeleteKameletBindingAction, Builder> {
+
+        private String name;
+
+        public Builder binding(String name) {
+            this.name = name;
+            return this;
+        }
+
+        @Override
+        public DeleteKameletBindingAction build() {
+            return new DeleteKameletBindingAction(this);
+        }
+    }
+}

--- a/java/steps/yaks-camel-k/src/main/java/org/citrusframework/yaks/camelk/actions/kamelet/VerifyKameletBindingAction.java
+++ b/java/steps/yaks-camel-k/src/main/java/org/citrusframework/yaks/camelk/actions/kamelet/VerifyKameletBindingAction.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.yaks.camelk.actions.kamelet;
+
+import com.consol.citrus.context.TestContext;
+import com.consol.citrus.exceptions.ValidationException;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import io.fabric8.kubernetes.client.dsl.base.CustomResourceDefinitionContext;
+import org.citrusframework.yaks.camelk.CamelKSettings;
+import org.citrusframework.yaks.camelk.CamelKSupport;
+import org.citrusframework.yaks.camelk.actions.AbstractCamelKAction;
+import org.citrusframework.yaks.camelk.model.DoneableKameletBinding;
+import org.citrusframework.yaks.camelk.model.KameletBinding;
+import org.citrusframework.yaks.camelk.model.KameletBindingList;
+
+/**
+ * Test action verifies Kamelet CRD is present on given namespace.
+ *
+ * @author Christoph Deppisch
+ */
+public class VerifyKameletBindingAction extends AbstractCamelKAction {
+
+    private final String name;
+
+    /**
+     * Constructor using given builder.
+     * @param builder
+     */
+    public VerifyKameletBindingAction(Builder builder) {
+        super("verify-kamelet-binding", builder);
+        this.name = builder.name;
+    }
+
+    @Override
+    public void doExecute(TestContext context) {
+        String bindingName = context.replaceDynamicContentInString(name);
+        CustomResourceDefinitionContext ctx = CamelKSupport.kameletCRDContext(CamelKSettings.getKameletApiVersion());
+        KameletBinding binding = getKubernetesClient().customResources(ctx, KameletBinding.class, KameletBindingList.class, DoneableKameletBinding.class)
+                .inNamespace(CamelKSettings.getNamespace())
+                .withName(bindingName)
+                .get();
+
+        if (binding == null) {
+            throw new ValidationException(String.format("Failed to retrieve KameletBinding '%s' in namespace '%s'", name, CamelKSettings.getNamespace()));
+        }
+
+        LOG.info("KamletBinding validation successful - All values OK!");
+        if (LOG.isDebugEnabled()) {
+            try {
+                LOG.debug(CamelKSupport.json().writeValueAsString(binding));
+            } catch (JsonProcessingException e) {
+                LOG.warn("Unable to dump KameletBinding data", e);
+            }
+        }
+    }
+
+    /**
+     * Action builder.
+     */
+    public static final class Builder extends AbstractCamelKAction.Builder<VerifyKameletBindingAction, Builder> {
+
+        private String name;
+
+        public Builder isAvailable() {
+            return this;
+        }
+
+        public Builder isAvailable(String integrationName) {
+            this.name = integrationName;
+            return this;
+        }
+
+        @Override
+        public VerifyKameletBindingAction build() {
+            return new VerifyKameletBindingAction(this);
+        }
+    }
+}

--- a/java/steps/yaks-camel-k/src/main/java/org/citrusframework/yaks/camelk/model/DoneableKameletBinding.java
+++ b/java/steps/yaks-camel-k/src/main/java/org/citrusframework/yaks/camelk/model/DoneableKameletBinding.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.yaks.camelk.model;
+
+import io.fabric8.kubernetes.api.builder.Function;
+import io.fabric8.kubernetes.client.CustomResourceDoneable;
+
+/**
+ * @author Christoph Deppisch
+ */
+public class DoneableKameletBinding extends CustomResourceDoneable<KameletBinding> {
+
+    public DoneableKameletBinding(KameletBinding resource, Function function) {
+        super(resource, function);
+    }
+}

--- a/java/steps/yaks-camel-k/src/main/java/org/citrusframework/yaks/camelk/model/KameletBinding.java
+++ b/java/steps/yaks-camel-k/src/main/java/org/citrusframework/yaks/camelk/model/KameletBinding.java
@@ -1,0 +1,131 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.yaks.camelk.model;
+
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.fabric8.kubernetes.client.CustomResource;
+import org.citrusframework.yaks.camelk.CamelKSettings;
+import org.citrusframework.yaks.camelk.CamelKSupport;
+
+/**
+ * @author Christoph Deppisch
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({"apiVersion", "kind", "metadata", "spec"})
+@JsonDeserialize(
+        using = JsonDeserializer.None.class
+)
+public class KameletBinding extends CustomResource {
+
+    @JsonProperty("spec")
+    private KameletBindingSpec spec = new KameletBindingSpec();
+
+    @Override
+    public String getApiVersion() {
+        return CamelKSupport.CAMELK_CRD_GROUP + "/" + CamelKSettings.getKameletApiVersion();
+    }
+
+    public KameletBindingSpec getSpec() {
+        return spec;
+    }
+
+    public void setSpec(KameletBindingSpec spec) {
+        this.spec = spec;
+    }
+
+    /**
+     * Fluent builder
+     */
+    public static class Builder {
+        private String name;
+        private Integration integration;
+        private KameletBindingSpec.Endpoint source;
+        private KameletBindingSpec.Endpoint sink;
+
+        public Builder name(String name) {
+            this.name = name;
+            return this;
+        }
+
+        public Builder integration(Integration integration) {
+            this.integration = integration;
+            return this;
+        }
+
+        public Builder source(KameletBindingSpec.Endpoint source) {
+            this.source = source;
+            return this;
+        }
+
+        public Builder source(String uri) {
+            return source(new KameletBindingSpec.Endpoint(uri));
+        }
+
+        public Builder source(KameletBindingSpec.Endpoint.ObjectReference ref, String properties) {
+            Map<String, Object> props = null;
+            if (properties != null && !properties.isEmpty()) {
+                props = CamelKSupport.yaml().load(properties);
+            }
+
+            return source(new KameletBindingSpec.Endpoint(ref, props));
+        }
+
+        public Builder sink(KameletBindingSpec.Endpoint sink) {
+            this.sink = sink;
+            return this;
+        }
+
+        public Builder sink(String uri) {
+            return sink(new KameletBindingSpec.Endpoint(uri));
+        }
+
+        public Builder sink(KameletBindingSpec.Endpoint.ObjectReference ref, String properties) {
+            Map<String, Object> props = null;
+            if (properties != null && !properties.isEmpty()) {
+                props = CamelKSupport.yaml().load(properties);
+            }
+
+            return sink(new KameletBindingSpec.Endpoint(ref, props));
+        }
+
+        public KameletBinding build() {
+            KameletBinding binding = new KameletBinding();
+            binding.getMetadata().setName(name);
+
+            if (integration != null) {
+                binding.getSpec().setIntegration(integration);
+            }
+
+            if (source != null) {
+                binding.getSpec().setSource(source);
+            }
+
+            if (sink != null) {
+                binding.getSpec().setSink(sink);
+            }
+
+            return binding;
+        }
+    }
+}

--- a/java/steps/yaks-camel-k/src/main/java/org/citrusframework/yaks/camelk/model/KameletBindingList.java
+++ b/java/steps/yaks-camel-k/src/main/java/org/citrusframework/yaks/camelk/model/KameletBindingList.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.yaks.camelk.model;
+
+import io.fabric8.kubernetes.client.CustomResourceList;
+
+/**
+ * @author Christoph Deppisch
+ */
+public class KameletBindingList extends CustomResourceList<KameletBinding> {
+}

--- a/java/steps/yaks-camel-k/src/main/java/org/citrusframework/yaks/camelk/model/KameletBindingSpec.java
+++ b/java/steps/yaks-camel-k/src/main/java/org/citrusframework/yaks/camelk/model/KameletBindingSpec.java
@@ -1,0 +1,208 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.yaks.camelk.model;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.fabric8.kubernetes.api.model.KubernetesResource;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({"integration", "source", "sink"})
+@JsonDeserialize(
+        using = JsonDeserializer.None.class
+)
+public class KameletBindingSpec implements KubernetesResource {
+
+    @JsonProperty("integration")
+    private Integration integration;
+
+    @JsonProperty("source")
+    private Endpoint source;
+
+    @JsonProperty("sink")
+    private Endpoint sink;
+
+    public void setSource(Endpoint source) {
+        this.source = source;
+    }
+
+    public Endpoint getSource() {
+        return source;
+    }
+
+    public void setSink(Endpoint sink) {
+        this.sink = sink;
+    }
+
+    public Endpoint getSink() {
+        return sink;
+    }
+
+    public void setIntegration(Integration integration) {
+        this.integration = integration;
+    }
+
+    public Integration getIntegration() {
+        return integration;
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    @JsonPropertyOrder({"ref", "uri", "properties"})
+    public static class Endpoint {
+        @JsonProperty("ref")
+        private ObjectReference ref;
+
+        @JsonProperty("uri")
+        private String uri;
+
+        @JsonProperty("properties")
+        private Map<String, Object> properties = new HashMap<>();
+
+        public Endpoint() {
+        }
+
+        public Endpoint(ObjectReference ref) {
+            this.ref = ref;
+        }
+
+        public Endpoint(ObjectReference ref, Map<String, Object> properties) {
+            this.ref = ref;
+            this.properties = properties;
+        }
+
+        public Endpoint(String uri) {
+            this.uri = uri;
+        }
+
+        public ObjectReference getRef() {
+            return ref;
+        }
+
+        public void setRef(ObjectReference ref) {
+            this.ref = ref;
+        }
+
+        public String getUri() {
+            return uri;
+        }
+
+        public void setUri(String uri) {
+            this.uri = uri;
+        }
+
+        public Map<String, Object> getProperties() {
+            return properties;
+        }
+
+        public void setProperties(Map<String, Object> properties) {
+            this.properties = properties;
+        }
+
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        @JsonPropertyOrder({"name", "kind", "namespace", "uid", "apiVersion", "resourceVersion", "fieldPath"})
+        public static class ObjectReference {
+            @JsonProperty("name")
+            private String name;
+            @JsonProperty("kind")
+            private String kind;
+            @JsonProperty("namespace")
+            private String namespace;
+            @JsonProperty("uid")
+            private String uid;
+            @JsonProperty("apiVersion")
+            private String apiVersion;
+            @JsonProperty("resourceVersion")
+            private String resourceVersion;
+            @JsonProperty("fieldPath")
+            private String fieldPath;
+
+            public ObjectReference() {
+                super();
+            }
+
+            public ObjectReference(String name, String kind, String namespace) {
+                this.name = name;
+                this.kind = kind;
+                this.namespace = namespace;
+            }
+
+            public String getName() {
+                return name;
+            }
+
+            public void setName(String name) {
+                this.name = name;
+            }
+
+            public String getKind() {
+                return kind;
+            }
+
+            public void setKind(String kind) {
+                this.kind = kind;
+            }
+
+            public String getNamespace() {
+                return namespace;
+            }
+
+            public void setNamespace(String namespace) {
+                this.namespace = namespace;
+            }
+
+            public String getUid() {
+                return uid;
+            }
+
+            public void setUid(String uid) {
+                this.uid = uid;
+            }
+
+            public String getApiVersion() {
+                return apiVersion;
+            }
+
+            public void setApiVersion(String apiVersion) {
+                this.apiVersion = apiVersion;
+            }
+
+            public String getResourceVersion() {
+                return resourceVersion;
+            }
+
+            public void setResourceVersion(String resourceVersion) {
+                this.resourceVersion = resourceVersion;
+            }
+
+            public String getFieldPath() {
+                return fieldPath;
+            }
+
+            public void setFieldPath(String fieldPath) {
+                this.fieldPath = fieldPath;
+            }
+        }
+    }
+
+}

--- a/java/steps/yaks-camel-k/src/test/java/org.citrusframework.yaks.camelk/KameletBindingBuilderTest.java
+++ b/java/steps/yaks-camel-k/src/test/java/org.citrusframework.yaks.camelk/KameletBindingBuilderTest.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.yaks.camelk;
+
+import java.io.IOException;
+
+import com.consol.citrus.util.FileUtils;
+import org.citrusframework.yaks.camelk.model.KameletBinding;
+import org.citrusframework.yaks.camelk.model.KameletBindingSpec;
+import org.citrusframework.yaks.kafka.KafkaSettings;
+import org.junit.Assert;
+import org.junit.Test;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.util.StringUtils;
+
+public class KameletBindingBuilderTest {
+
+	@Test
+	public void buildComplexKameletBinding() throws IOException {
+		KameletBindingSpec.Endpoint.ObjectReference sourceRef = new KameletBindingSpec.Endpoint.ObjectReference();
+		sourceRef.setName("timer-source");
+		sourceRef.setKind("Kamelet");
+		sourceRef.setNamespace(CamelKSettings.getNamespace());
+
+		KameletBindingSpec.Endpoint source = new KameletBindingSpec.Endpoint(sourceRef);
+		source.getProperties().put("message", "Hello World");
+
+		KameletBindingSpec.Endpoint.ObjectReference sinkRef = new KameletBindingSpec.Endpoint.ObjectReference();
+		sinkRef.setName("hello-topic");
+		sinkRef.setKind("KafkaTopic");
+		sinkRef.setNamespace(KafkaSettings.getNamespace());
+
+		KameletBindingSpec.Endpoint sink = new KameletBindingSpec.Endpoint(sinkRef);
+
+		KameletBinding binding = new KameletBinding.Builder()
+				.name("time-source-kafka")
+				.source(source)
+				.sink(sink)
+				.build();
+
+		final String json = CamelKSupport.json().writeValueAsString(binding);
+		Assert.assertEquals(StringUtils.trimAllWhitespace(
+				FileUtils.readToString(new ClassPathResource("kamelet-binding.json", KameletBindingBuilderTest.class))),
+				StringUtils.trimAllWhitespace(json));
+	}
+}

--- a/java/steps/yaks-camel-k/src/test/java/org.citrusframework.yaks.camelk/KameletBuilderTest.java
+++ b/java/steps/yaks-camel-k/src/test/java/org.citrusframework.yaks.camelk/KameletBuilderTest.java
@@ -54,7 +54,7 @@ public class KameletBuilderTest {
 						"    period: \"#property:period\"\n" +
 						"  steps:\n" +
 						"  - set-body:\n" +
-						"      constant: \"#property:message\"\n" +
+						"      constant: \"{{message}}\"\n" +
 						"  - to: \"kamelet:sink\"")
 				.build();
 

--- a/java/steps/yaks-camel-k/src/test/resources/kamelet-binding.yaml
+++ b/java/steps/yaks-camel-k/src/test/resources/kamelet-binding.yaml
@@ -1,0 +1,34 @@
+# ---------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ---------------------------------------------------------------------------
+
+apiVersion: camel.apache.org/v1alpha1
+kind: KameletBinding
+metadata:
+  name: timer-source-binding
+spec:
+  source:
+    ref:
+      kind: Kamelet
+      apiVersion: camel.apache.org/v1alpha1
+      name: timer-source
+    properties:
+      message: "Hello world!"
+  sink:
+    ref:
+      kind: KafkaTopic
+      apiVersion: kafka.strimzi.io/v1beta1
+      name: hello-topic

--- a/java/steps/yaks-camel-k/src/test/resources/org/citrusframework/yaks/camelk/camelk.integration.feature
+++ b/java/steps/yaks-camel-k/src/test/resources/org/citrusframework/yaks/camelk/camelk.integration.feature
@@ -3,7 +3,7 @@ Feature: Camel-K integration
   Background:
     Given Camel-K resource polling configuration
     | maxAttempts          | 10   |
-    | delayBetweemAttempts | 1000 |
+    | delayBetweenAttempts | 1000 |
 
   Scenario: Create integration
     Given create Camel-K integration helloworld.groovy

--- a/java/steps/yaks-camel-k/src/test/resources/org/citrusframework/yaks/camelk/camelk.kamelet.feature
+++ b/java/steps/yaks-camel-k/src/test/resources/org/citrusframework/yaks/camelk/camelk.kamelet.feature
@@ -49,3 +49,28 @@ from:
     And load Camel-K integration timer-to-log.groovy
     Then Kamelet timer-source should be available
 
+  Scenario: Bind Kamelet to Kafka
+    Given KameletBinding source properties
+      | message  | Hello World |
+    And bind Kamelet timer-source to Kafka topic hello-topic
+    When create KameletBinding timer-source-kafka
+    Then KameletBinding timer-source-kafka should be available
+
+  Scenario: Bind Kamelet to Knative
+    Given KameletBinding source properties
+      | message  | Hello World |
+    And bind Kamelet timer-source to Knative channel hello-topic of kind InMemoryChannel
+    When create KameletBinding timer-source-knative
+    Then KameletBinding timer-source-knative should be available
+
+  Scenario: Bind Kamelet to Uri
+    Given KameletBinding source properties
+      | message  | Hello World |
+    And bind Kamelet timer-source to uri https://greeting-service.svc.cluster.local
+    When create KameletBinding timer-source-uri
+    Then KameletBinding timer-source-uri should be available
+
+  Scenario: Create KameletBinding from file
+    Given load KameletBinding kamelet-binding.yaml
+    Then KameletBinding timer-source-binding should be available
+

--- a/java/steps/yaks-camel-k/src/test/resources/org/citrusframework/yaks/camelk/kamelet-binding.json
+++ b/java/steps/yaks-camel-k/src/test/resources/org/citrusframework/yaks/camelk/kamelet-binding.json
@@ -1,0 +1,26 @@
+{
+  "apiVersion": "camel.apache.org/v1alpha1",
+  "kind": "KameletBinding",
+  "metadata": {
+    "name": "time-source-kafka"
+  },
+  "spec": {
+    "source": {
+      "ref": {
+        "name": "timer-source",
+        "kind": "Kamelet",
+        "namespace": "default"
+      },
+      "properties": {
+        "message": "Hello World"
+      }
+    },
+    "sink": {
+      "ref": {
+        "name": "hello-topic",
+        "kind": "KafkaTopic",
+        "namespace": "default"
+      }
+    }
+  }
+}

--- a/java/steps/yaks-camel-k/src/test/resources/org/citrusframework/yaks/camelk/kamelet.json
+++ b/java/steps/yaks-camel-k/src/test/resources/org/citrusframework/yaks/camelk/kamelet.json
@@ -40,7 +40,7 @@
         "steps": [
           {
             "set-body": {
-              "constant": "#property:message"
+              "constant": "{{message}}"
             }
           },
           {

--- a/java/steps/yaks-camel-k/src/test/resources/timer-source.kamelet.yaml
+++ b/java/steps/yaks-camel-k/src/test/resources/timer-source.kamelet.yaml
@@ -50,5 +50,5 @@ spec:
         period: "#property:period"
       steps:
         - set-body:
-            constant: "#property:message"
+            constant: "{{message}}"
         - to: "kamelet:sink"

--- a/java/steps/yaks-kafka/pom.xml
+++ b/java/steps/yaks-kafka/pom.xml
@@ -30,6 +30,13 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.citrusframework.yaks</groupId>
+      <artifactId>yaks-standard</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
       <groupId>io.cucumber</groupId>
       <artifactId>cucumber-java</artifactId>
     </dependency>
@@ -67,12 +74,6 @@
     <dependency>
       <groupId>com.consol.citrus</groupId>
       <artifactId>citrus-validation-text</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.citrusframework.yaks</groupId>
-      <artifactId>yaks-standard</artifactId>
-      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/java/steps/yaks-kafka/src/main/java/org/citrusframework/yaks/kafka/KafkaSettings.java
+++ b/java/steps/yaks-kafka/src/main/java/org/citrusframework/yaks/kafka/KafkaSettings.java
@@ -17,17 +17,22 @@
 
 package org.citrusframework.yaks.kafka;
 
+import org.citrusframework.yaks.YaksSettings;
+
 /**
  * @author Christoph Deppisch
  */
 public class KafkaSettings {
 
-    private static final String KNATIVE_PROPERTY_PREFIX = "yaks.kafka.";
-    private static final String KNATIVE_ENV_PREFIX = "YAKS_KAFKA_";
+    private static final String KAFKA_PROPERTY_PREFIX = "yaks.kafka.";
+    private static final String KAFKA_ENV_PREFIX = "YAKS_KAFKA_";
 
-    private static final String CONSUMER_TIMEOUT_PROPERTY = KNATIVE_PROPERTY_PREFIX + "timeout";
-    private static final String CONSUMER_TIMEOUT_ENV = KNATIVE_ENV_PREFIX + "TIMEOUT";
+    private static final String CONSUMER_TIMEOUT_PROPERTY = KAFKA_PROPERTY_PREFIX + "timeout";
+    private static final String CONSUMER_TIMEOUT_ENV = KAFKA_ENV_PREFIX + "TIMEOUT";
     private static final String CONSUMER_TIMEOUT_DEFAULT = "60000";
+
+    static final String NAMESPACE_PROPERTY = KAFKA_PROPERTY_PREFIX + "namespace";
+    static final String NAMESPACE_ENV = KAFKA_ENV_PREFIX + "NAMESPACE";
 
     private KafkaSettings() {
         // prevent instantiation of utility class
@@ -40,5 +45,14 @@ public class KafkaSettings {
     public static long getConsumerTimeout() {
         return Long.parseLong(System.getProperty(CONSUMER_TIMEOUT_PROPERTY,
                 System.getenv(CONSUMER_TIMEOUT_ENV) != null ? System.getenv(CONSUMER_TIMEOUT_ENV) : CONSUMER_TIMEOUT_DEFAULT));
+    }
+
+    /**
+     * Namespace to work on when performing Kafka client operations such as creating brokers, topics and so on.
+     * @return
+     */
+    public static String getNamespace() {
+        return System.getProperty(NAMESPACE_PROPERTY,
+                System.getenv(NAMESPACE_ENV) != null ? System.getenv(NAMESPACE_ENV) : YaksSettings.getDefaultNamespace());
     }
 }


### PR DESCRIPTION
Let user create/delete/verify KameletBinding custom resources. Provide steps to create KameletBinding specifications with source and sink. Once KameletBinding is created user can verify the ready state of the CR. Steps provide convenient ways to bind a Kamelet to a Kafka topic, a Knative channel or a service URI.

*Create KameletBinding from file resource*
```gherkin
Scenario: Create KameletBinding from file
    Given load KameletBinding kamelet-binding.yaml
    Then KameletBinding timer-source-binding should be available
```

*bind Kamelet to Knative*
```gherkin
Scenario: Bind Kamelet to Knative
    Given KameletBinding source properties
      | message  | Hello Knative |
    And bind Kamelet timer-source to Knative channel hello-topic of kind InMemoryChannel
    When create KameletBinding timer-source-knative
    Then KameletBinding timer-source-knative should be available
```

*bind Kamelet to Kafka*
```gherkin
Scenario: Bind Kamelet to Kafka
    Given KameletBinding source properties
      | message  | Hello Kafka |
    And bind Kamelet timer-source to Kafka topic hello-topic
```

*bind Kamelet to URI*
```gherkin
Scenario: Bind Kamelet to URI
    Given KameletBinding source properties
      | message  | Hello Service URI |
    And bind Kamelet timer-source to uri https://greeting-service.svc.cluster.local
```