### PR TITLE
fix(#157): Improve JMS steps

### DIFF
--- a/examples/kamelets/kamelet-uri-binding.yaml
+++ b/examples/kamelets/kamelet-uri-binding.yaml
@@ -28,4 +28,4 @@ spec:
     properties:
       message: "Hello world!"
   sink:
-    uri: http://${host}:${port}
+    uri: http://greeting-service.${YAKS_NAMESPACE}/greeting

--- a/java/steps/yaks-http/src/main/java/org/citrusframework/yaks/http/HttpSettings.java
+++ b/java/steps/yaks-http/src/main/java/org/citrusframework/yaks/http/HttpSettings.java
@@ -31,7 +31,7 @@ public class HttpSettings {
 
     private static final String SERVER_NAME_PROPERTY = HTTP_PROPERTY_PREFIX + "server.name";
     private static final String SERVER_NAME_ENV = HTTP_ENV_PREFIX + "SERVER_NAME";
-    private static final String SERVER_NAME_DEFAULT = "yaks-k8s-service";
+    private static final String SERVER_NAME_DEFAULT = "yaks-http-server";
 
     private static final String SERVER_PORT_PROPERTY = HTTP_PROPERTY_PREFIX + "server.port";
     private static final String SERVER_PORT_ENV = HTTP_ENV_PREFIX + "SERVER_PORT";

--- a/java/steps/yaks-jms/pom.xml
+++ b/java/steps/yaks-jms/pom.xml
@@ -28,47 +28,6 @@
   <artifactId>yaks-jms</artifactId>
   <name>YAKS :: Steps :: JMS</name>
 
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.activemq.tooling</groupId>
-        <artifactId>activemq-maven-plugin</artifactId>
-        <version>${activemq.version}</version>
-        <configuration>
-          <fork>true</fork>
-          <systemProperties>
-            <property>
-              <name>log4j.configuration</name>
-              <value>log4j.properties</value>
-            </property>
-          </systemProperties>
-        </configuration>
-        <executions>
-          <execution>
-            <phase>process-test-resources</phase>
-            <id>start-broker</id>
-            <goals>
-              <goal>run</goal>
-            </goals>
-            <configuration>
-              <skip>${skipTests}</skip>
-            </configuration>
-          </execution>
-          <execution>
-            <id>stop-broker</id>
-            <phase>prepare-package</phase>
-            <goals>
-              <goal>stop</goal>
-            </goals>
-            <configuration>
-              <skip>${skipTests}</skip>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-    </plugins>
-  </build>
-
   <dependencies>
     <dependency>
       <groupId>io.cucumber</groupId>
@@ -128,6 +87,12 @@
       <groupId>org.citrusframework.yaks</groupId>
       <artifactId>yaks-standard</artifactId>
       <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.activemq</groupId>
+      <artifactId>activemq-broker</artifactId>
+      <version>${activemq.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/java/steps/yaks-jms/src/main/java/org/citrusframework/yaks/jms/JmsSettings.java
+++ b/java/steps/yaks-jms/src/main/java/org/citrusframework/yaks/jms/JmsSettings.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.yaks.jms;
+
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * @author Christoph Deppisch
+ */
+public class JmsSettings {
+
+    private static final String JMS_PROPERTY_PREFIX = "yaks.kubernetes.";
+    private static final String JMS_ENV_PREFIX = "YAKS_JMS_";
+
+    private static final String ENDPOINT_NAME_PROPERTY = JMS_PROPERTY_PREFIX + "endpoint.name";
+    private static final String ENDPOINT_NAME_ENV = JMS_ENV_PREFIX + "ENDPOINT_NAME";
+    private static final String ENDPOINT_NAME_DEFAULT = "yaks-jms-endpoint";
+
+    private static final String TIMEOUT_PROPERTY = JMS_PROPERTY_PREFIX + "timeout";
+    private static final String TIMEOUT_ENV = JMS_ENV_PREFIX + "TIMEOUT";
+
+    private JmsSettings() {
+        // prevent instantiation of utility class
+    }
+
+    /**
+     * Request timeout when receiving messages.
+     * @return
+     */
+    public static long getTimeout() {
+        return Optional.ofNullable(System.getProperty(TIMEOUT_PROPERTY, System.getenv(TIMEOUT_ENV)))
+                .map(Long::parseLong)
+                .orElse(TimeUnit.SECONDS.toMillis(60));
+    }
+
+    /**
+     * Default endpoint name to use when creating a Kafka endpoint.
+     * @return
+     */
+    public static String getEndpointName() {
+        return System.getProperty(ENDPOINT_NAME_PROPERTY,
+                System.getenv(ENDPOINT_NAME_ENV) != null ? System.getenv(ENDPOINT_NAME_ENV) : ENDPOINT_NAME_DEFAULT);
+    }
+}

--- a/java/steps/yaks-jms/src/test/java/org/citrusframework/yaks/jms/JmsBrokerConfiguration.java
+++ b/java/steps/yaks-jms/src/test/java/org/citrusframework/yaks/jms/JmsBrokerConfiguration.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.citrusframework.yaks.jms;
+
+import org.apache.activemq.broker.BrokerFactory;
+import org.apache.activemq.broker.BrokerService;
+import org.springframework.beans.factory.BeanCreationException;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class JmsBrokerConfiguration {
+
+	@Bean(initMethod = "start", destroyMethod = "stop")
+	public BrokerService messageBroker() {
+		try {
+			BrokerService messageBroker = BrokerFactory.createBroker("broker:tcp://localhost:61616");
+			messageBroker.setPersistent(false);
+			messageBroker.setUseJmx(false);
+			return messageBroker;
+		} catch (Exception e) {
+			throw new BeanCreationException("Failed to create embedded message broker", e);
+		}
+	}
+}

--- a/java/steps/yaks-jms/src/test/resources/citrus-application.properties
+++ b/java/steps/yaks-jms/src/test/resources/citrus-application.properties
@@ -1,0 +1,18 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+citrus.spring.java.config=org.citrusframework.yaks.jms.JmsBrokerConfiguration

--- a/java/steps/yaks-jms/src/test/resources/org/citrusframework/yaks/jms/jms-multiline.feature
+++ b/java/steps/yaks-jms/src/test/resources/org/citrusframework/yaks/jms/jms-multiline.feature
@@ -1,0 +1,32 @@
+Feature: JMS multiline steps
+
+  Background:
+    Given JMS connection factory
+      | type       | org.apache.activemq.ActiveMQConnectionFactory |
+      | brokerUrl  | tcp://localhost:61616 |
+
+  Scenario: Predefined multiline body
+    Given JMS message body
+      """
+      {
+        "message": "Hello from YAKS!"
+      }
+      """
+    When send JMS message to destination hello
+    Then verify JMS message body
+      """
+      { "message": "Hello from YAKS!" }
+      """
+    And receive JMS message on destination hello
+
+  Scenario: Multiline body
+    When send JMS message with body
+      """
+      {
+        "message": "Hello from YAKS!"
+      }
+      """
+    Then expect JMS message with body
+      """
+      { "message": "Hello from YAKS!" }
+      """

--- a/java/steps/yaks-jms/src/test/resources/org/citrusframework/yaks/jms/jms.feature
+++ b/java/steps/yaks-jms/src/test/resources/org/citrusframework/yaks/jms/jms.feature
@@ -5,39 +5,41 @@ Feature: JMS steps
       | type       | org.apache.activemq.ActiveMQConnectionFactory |
       | brokerUrl  | tcp://localhost:61616 |
     Given JMS destination: test
+    Given variable body is "citrus:randomString(10)"
+    Given variable key is "citrus:randomString(10)"
+    Given variable value is "citrus:randomString(10)"
+    Given JMS consumer timeout is 5000 milliseconds
+
+  Scenario: Send and receive with predefined body and headers
+    Given JMS message body: ${body}
+    And JMS message header ${key}="${value}"
+    When send JMS message
+    Then verify JMS message body: ${body}
+    And verify JMS message header ${key} is "${value}"
+    And receive JMS message
 
   Scenario: Send and receive body and headers
     Given variable body is "citrus:randomString(10)"
     Given variable key is "citrus:randomString(10)"
     Given variable value is "citrus:randomString(10)"
-    When send message to JMS broker with body and headers: ${body}
+    When send JMS message with body and headers: ${body}
       | ${key} | ${value} |
-    Then expect message in JMS broker with body and headers: ${body}
+    Then expect JMS message with body and headers: ${body}
       | ${key} | ${value} |
 
-  Scenario: Send and receive multiline body
-    When send message to JMS broker with body
-    """
-    {
-      "message": "Hello from YAKS!"
-    }
-    """
-    Then expect message in JMS broker with body
-    """
-    {
-      "message": "Hello from YAKS!"
-    }
-    """
+  Scenario: Send and receive body
+    When send JMS message with body: {"message": "Hello from YAKS!"}
+    Then expect JMS message with body: {"message": "Hello from YAKS!"}
 
   Scenario: Send receive message with selector
     Given variable correctBody is "citrus:randomString(10)"
     And variable tag is "citrus:randomString(10)"
     And jms selector: tag='${tag}'
-    Given message in JMS broker with body and headers: citrus:randomString(10)
+    Given JMS message with body and headers: citrus:randomString(10)
       | tag | citrus:randomString(10) |
-    And message in JMS broker with body and headers: ${correctBody}
+    And JMS message with body and headers: ${correctBody}
       | tag | ${tag} |
-    And message in JMS broker with body and headers: citrus:randomString(10)
+    And JMS message with body and headers: citrus:randomString(10)
       | tag | citrus:randomString(10) |
-    Then expect message in JMS broker with body and headers: ${correctBody}
+    Then expect JMS message with body and headers: ${correctBody}
       | tag | ${tag} |

--- a/java/steps/yaks-kafka/src/main/java/org/citrusframework/yaks/kafka/KafkaSettings.java
+++ b/java/steps/yaks-kafka/src/main/java/org/citrusframework/yaks/kafka/KafkaSettings.java
@@ -31,6 +31,10 @@ public class KafkaSettings {
     private static final String CONSUMER_TIMEOUT_ENV = KAFKA_ENV_PREFIX + "TIMEOUT";
     private static final String CONSUMER_TIMEOUT_DEFAULT = "60000";
 
+    private static final String ENDPOINT_NAME_PROPERTY = KAFKA_PROPERTY_PREFIX + "endpoint.name";
+    private static final String ENDPOINT_NAME_ENV = KAFKA_ENV_PREFIX + "ENDPOINT_NAME";
+    private static final String ENDPOINT_NAME_DEFAULT = "yaks-kafka-endpoint";
+
     static final String NAMESPACE_PROPERTY = KAFKA_PROPERTY_PREFIX + "namespace";
     static final String NAMESPACE_ENV = KAFKA_ENV_PREFIX + "NAMESPACE";
 
@@ -45,6 +49,15 @@ public class KafkaSettings {
     public static long getConsumerTimeout() {
         return Long.parseLong(System.getProperty(CONSUMER_TIMEOUT_PROPERTY,
                 System.getenv(CONSUMER_TIMEOUT_ENV) != null ? System.getenv(CONSUMER_TIMEOUT_ENV) : CONSUMER_TIMEOUT_DEFAULT));
+    }
+
+    /**
+     * Default endpoint name to use when creating a Kafka endpoint.
+     * @return
+     */
+    public static String getEndpointName() {
+        return System.getProperty(ENDPOINT_NAME_PROPERTY,
+                System.getenv(ENDPOINT_NAME_ENV) != null ? System.getenv(ENDPOINT_NAME_ENV) : ENDPOINT_NAME_DEFAULT);
     }
 
     /**

--- a/java/steps/yaks-kafka/src/main/java/org/citrusframework/yaks/kafka/KafkaSteps.java
+++ b/java/steps/yaks-kafka/src/main/java/org/citrusframework/yaks/kafka/KafkaSteps.java
@@ -56,20 +56,20 @@ public class KafkaSteps {
     private Integer partition;
     private String topic = "test";
 
-    private long timeout = KafkaSettings.getConsumerTimeout();
+    private String endpointName = KafkaSettings.getEndpointName();
 
-    private static final String KAFKA_ENDPOINT_NAME = "kafkaEndpoint";
+    private long timeout = KafkaSettings.getConsumerTimeout();
 
     @Before
     public void before(Scenario scenario) {
         if (kafkaEndpoint == null) {
             if (citrus.getCitrusContext().getReferenceResolver().resolveAll(KafkaEndpoint.class).size() == 1L) {
                 kafkaEndpoint = citrus.getCitrusContext().getReferenceResolver().resolve(KafkaEndpoint.class);
-            } else if (citrus.getCitrusContext().getReferenceResolver().isResolvable(KAFKA_ENDPOINT_NAME)) {
-                kafkaEndpoint = citrus.getCitrusContext().getReferenceResolver().resolve(KAFKA_ENDPOINT_NAME, KafkaEndpoint.class);
+            } else if (citrus.getCitrusContext().getReferenceResolver().isResolvable(endpointName)) {
+                kafkaEndpoint = citrus.getCitrusContext().getReferenceResolver().resolve(endpointName, KafkaEndpoint.class);
             } else {
                 kafkaEndpoint = new KafkaEndpointBuilder().build();
-                citrus.getCitrusContext().getReferenceResolver().bind(KAFKA_ENDPOINT_NAME, kafkaEndpoint);
+                citrus.getCitrusContext().getReferenceResolver().bind(endpointName, kafkaEndpoint);
             }
         }
 
@@ -105,6 +105,17 @@ public class KafkaSteps {
     public void setConsumerConfig(DataTable properties) {
         Map<String, Object> consumerProperties = properties.asMap(String.class, Object.class);
         kafkaEndpoint.getEndpointConfiguration().setConsumerProperties(consumerProperties);
+    }
+
+    @Given("^(?:K|k)afka endpoint \"([^\"\\s]+)\"$")
+    public void setServer(String name) {
+        this.endpointName = name;
+        if (citrus.getCitrusContext().getReferenceResolver().isResolvable(name)) {
+            kafkaEndpoint = citrus.getCitrusContext().getReferenceResolver().resolve(name, KafkaEndpoint.class);
+        } else if (kafkaEndpoint != null) {
+            citrus.getCitrusContext().getReferenceResolver().bind(endpointName, kafkaEndpoint);
+            kafkaEndpoint.setName(endpointName);
+        }
     }
 
     @Given("^(?:K|k)afka message key: (.+)$")
@@ -204,20 +215,20 @@ public class KafkaSteps {
         sendMessageBody(body);
     }
 
-    @Then("^(?:expect|verify) (?:K|k)afka message with body and headers: (.+)$")
+    @Then("^(?:receive|expect|verify) (?:K|k)afka message with body and headers: (.+)$")
     public void receiveFromKafka(String body, DataTable headers) {
         setMessageBody(body);
         addMessageHeaders(headers);
         receiveMessage();
     }
 
-    @Then("^(?:expect|verify) (?:K|k)afka message with body: (.+)$")
+    @Then("^(?:receive|expect|verify) (?:K|k)afka message with body: (.+)$")
     public void receiveMessageBody(String body) {
         setMessageBody(body);
         receiveMessage();
     }
 
-    @Then("^(?:expect|verify) (?:K|k)afka message with body$")
+    @Then("^(?:receive|expect|verify) (?:K|k)afka message with body$")
     public void receiveMessageBodyMultiline(String body) {
         receiveMessageBody(body);
     }

--- a/java/steps/yaks-kafka/src/test/resources/org/citrusframework/yaks/kafka/kafka-multiline.feature
+++ b/java/steps/yaks-kafka/src/test/resources/org/citrusframework/yaks/kafka/kafka-multiline.feature
@@ -32,4 +32,3 @@ Feature: Kafka multiline steps
       """
       { "message": "Hello from YAKS!" }
       """
-


### PR DESCRIPTION
- Customize consumer timeout
- Predefine message body and headers before send/receive
- Load JMS endpoint from Citrus configuration if present
- Explicitly send/receive from destination
- Adjust steps and wording to to align with other modules (e.g. Kafka)