### PR TITLE
fix(#159): Reset test status on update

### DIFF
--- a/pkg/apis/yaks/v1alpha1/test_types.go
+++ b/pkg/apis/yaks/v1alpha1/test_types.go
@@ -157,6 +157,8 @@ const (
 	TestPhaseError TestPhase = "Error"
 	// TestPhaseDeleting
 	TestPhaseDeleting TestPhase = "Deleting"
+	// TestPhaseUpdating is a phase where the operator is not supposed to interact with the resource
+	TestPhaseUpdating TestPhase = "Updating"
 )
 
 func (phase TestPhase) AsError() error {

--- a/pkg/cmd/test.go
+++ b/pkg/cmd/test.go
@@ -470,12 +470,19 @@ func (o *testCmdOptions) createAndRunTest(c client.Client, rawName string, runCo
 		if err != nil {
 			return nil, err
 		}
+		// Hold the resource from the operator controller
+		clone.Status.Phase = v1alpha1.TestPhaseUpdating
+		err = c.Status().Update(o.Context, clone)
+		if err != nil {
+			return nil, err
+		}
+		// Update the spec
 		test.ResourceVersion = clone.ResourceVersion
 		err = c.Update(o.Context, &test)
 		if err != nil {
 			return nil, err
 		}
-		// Reset status as well
+		// Reset status
 		test.Status = v1alpha1.TestStatus{}
 		err = c.Status().Update(o.Context, &test)
 	}

--- a/pkg/controller/test/noop.go
+++ b/pkg/controller/test/noop.go
@@ -1,0 +1,48 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package test
+
+import (
+	"context"
+	"github.com/citrusframework/yaks/pkg/apis/yaks/v1alpha1"
+)
+
+// NewNoopAction is used to put an test resource out of the operator lifecycle.
+//
+// The resource must be updated by an external entity (e.g. the yaks CLI) to a new state when ready
+// to start a new workflow.
+func NewNoopAction() Action {
+	return &noopAction{}
+}
+
+type noopAction struct {
+	baseAction
+}
+
+func (action *noopAction) Name() string {
+	return "noop"
+}
+
+func (action *noopAction) CanHandle(test *v1alpha1.Test) bool {
+	return test.Status.Phase == v1alpha1.TestPhaseUpdating
+}
+
+func (action *noopAction) Handle(ctx context.Context, test *v1alpha1.Test) (*v1alpha1.Test, error) {
+	// Do nothing and return no object to update
+	return nil, nil
+}

--- a/pkg/controller/test/test_controller.go
+++ b/pkg/controller/test/test_controller.go
@@ -44,7 +44,7 @@ import (
 * business logic.  Delete these comments after modifying this file.*
  */
 
-// Add creates a new Integration Controller and adds it to the Manager. The Manager will set fields on the Controller
+// Add creates a new Test Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
 func Add(mgr manager.Manager) error {
 	c, err := client.FromManager(mgr)
@@ -71,13 +71,13 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 		return err
 	}
 
-	// Watch for changes to primary resource Integration
+	// Watch for changes to primary resource Test
 	err = c.Watch(&source.Kind{Type: &v1alpha1.Test{}}, &handler.EnqueueRequestForObject{}, predicate.Funcs{
 		UpdateFunc: func(e event.UpdateEvent) bool {
 			oldTest := e.ObjectOld.(*v1alpha1.Test)
 			newTest := e.ObjectNew.(*v1alpha1.Test)
-			// Ignore updates to the integration status in which case metadata.Generation does not change,
-			// or except when the integration phase changes as it's used to transition from one phase
+			// Ignore updates to the test status in which case metadata.Generation does not change,
+			// or except when the test phase changes as it's used to transition from one phase
 			// to another
 			return oldTest.Generation != newTest.Generation ||
 				oldTest.Status.Phase != newTest.Status.Phase
@@ -128,8 +128,8 @@ type ReconcileIntegrationTest struct {
 	config *rest.Config
 }
 
-// Reconcile reads that state of the cluster for a Integration object and makes changes based on the state read
-// and what is in the Integration.Spec
+// Reconcile reads that state of the cluster for a Test object and makes changes based on the state read
+// and what is in the Test.Spec
 // Note:
 // The Controller will requeue the Request to be processed again if the returned error is non-nil or
 // Result.Requeue is true, otherwise upon completion it will remove the work from the queue.
@@ -166,6 +166,7 @@ func (r *ReconcileIntegrationTest) Reconcile(request reconcile.Request) (reconci
 		NewStartAction(),
 		NewEvaluateAction(),
 		NewMonitorAction(),
+		NewNoopAction(),
 	}
 
 	for _, a := range actions {


### PR DESCRIPTION
Introduce new test phase updating so operator is not handling test changes anymore. In this phase update the test status and the test spec when updating an existing test. This makes sure to reset the test status properly on the update. Also might fix #74 where status updates and operator changes interfere with each other.

Fixes #159 
Fixes #74 