### PR TITLE
fix(#172): Fix operator setup for temporary namespace

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -21,13 +21,12 @@ on:
   schedule:
     - cron: "0 0 * * *"
   push:
-    tags:
-      - '*pinned*'
+    branches:
+      - snapshot-release
 
 jobs:
   release:
     runs-on: ubuntu-latest
-    needs: build
     if: github.ref == 'refs/heads/master' && github.repository == 'citrusframework/yaks'
 
     steps:

--- a/pkg/cmd/config/config.go
+++ b/pkg/cmd/config/config.go
@@ -18,11 +18,15 @@ limitations under the License.
 package config
 
 import (
-    "github.com/citrusframework/yaks/pkg/util/olm"
     "io/ioutil"
     "os"
 
     "gopkg.in/yaml.v2"
+)
+
+const (
+    OperatorNamespaceOpenShift  = "openshift-operators"
+    OperatorNamespaceKubernetes = "kube-operators"
 )
 
 type RunConfig struct {
@@ -103,7 +107,6 @@ type NamespaceConfig struct {
 }
 
 type OperatorConfig struct {
-    Global    bool   `yaml:"global"`
     Namespace string `yaml:"namespace"`
 }
 
@@ -113,12 +116,7 @@ func NewWithDefaults() *RunConfig {
         Temporary:  false,
     }
 
-    operator := OperatorConfig {
-        Global: true,
-        Namespace: olm.DefaultGlobalNamespace,
-    }
-
-    var config = Config {Recursive: true, Namespace: ns, Operator: operator}
+    var config = Config {Recursive: true, Namespace: ns}
     return &RunConfig {Config: config, BaseDir: ""}
 }
 

--- a/pkg/cmd/install.go
+++ b/pkg/cmd/install.go
@@ -57,7 +57,7 @@ func newCmdInstall(rootCmdOptions *RootCmdOptions) (*cobra.Command, *installCmdO
 	cmd.Flags().String("cluster-type", "", "Set explicitly the cluster type to Kubernetes or OpenShift")
 	cmd.Flags().Bool("skip-operator-setup", false, "Do not install the operator in the namespace (in case there's a global one)")
 	cmd.Flags().Bool("skip-cluster-setup", false, "Skip the cluster-setup phase")
-	cmd.Flags().Bool("global", false, "Configure the operator to watch all namespaces. No integration platform is created.")
+	cmd.Flags().Bool("global", true, "Configure the operator to watch all namespaces")
 	cmd.Flags().Bool("force", false, "Force replacement of configuration resources when already present.")
 	cmd.Flags().String("operator-image", "", "Set the operator Image used for the operator deployment")
 	cmd.Flags().String("operator-image-pull-policy", "", "Set the operator ImagePullPolicy used for the operator deployment")

--- a/pkg/controller/test/util.go
+++ b/pkg/controller/test/util.go
@@ -19,15 +19,7 @@ package test
 
 import (
 	"fmt"
-	"os"
-	"strings"
-
 	"github.com/citrusframework/yaks/pkg/apis/yaks/v1alpha1"
-)
-
-const (
-	OperatorWatchNamespaceEnv = "WATCH_NAMESPACE"
-	OperatorNamespaceEnv      = "OPERATOR_NAMESPACE"
 )
 
 // TestPodNameFor returns the name to use for the testing pod
@@ -38,20 +30,4 @@ func TestPodNameFor(test *v1alpha1.Test) string {
 // TestResourceNameFor returns the name to use for generic testing resources
 func TestResourceNameFor(test *v1alpha1.Test) string {
 	return fmt.Sprintf("test-%s", test.Name)
-}
-
-// IsCurrentOperatorGlobal returns true if the operator is configured to watch all namespaces
-func IsCurrentOperatorGlobal() bool {
-	if watchNamespace, envSet := os.LookupEnv(OperatorWatchNamespaceEnv); !envSet || strings.TrimSpace(watchNamespace) == "" {
-		return true
-	}
-	return false
-}
-
-// GetOperatorNamespace returns the namespace where the current operator is located (if set)
-func GetOperatorNamespace() string {
-	if podNamespace, envSet := os.LookupEnv(OperatorNamespaceEnv); envSet {
-		return podNamespace
-	}
-	return ""
 }


### PR DESCRIPTION
Fixes #172 

- Make global operator the default in install
- Global operator also handles temporary namespaces
- Non global operator automatically installing a new operator instance to the temporary namespace
- Verify global operator config and decide which way to go when creating a temporary namespace