### PR TITLE
chore: Improve S2I image construction

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -47,7 +47,7 @@
     <kubernetes-client.version>4.10.3</kubernetes-client.version>
     <knative-client.version>4.10.3</knative-client.version>
     <postgresql.version>9.4.1212</postgresql.version>
-    <testcontainers.version>1.10.7</testcontainers.version>
+    <testcontainers.version>1.15.0-rc2</testcontainers.version>
     <apicurio.version>1.1.2</apicurio.version>
     <assertj-core.version>3.14.0</assertj-core.version>
     <s3-storage-wagon.version>2.3</s3-storage-wagon.version>

--- a/java/runtime/yaks-runtime-maven/pom.xml
+++ b/java/runtime/yaks-runtime-maven/pom.xml
@@ -28,19 +28,6 @@
   <artifactId>yaks-runtime-maven</artifactId>
   <name>YAKS :: Runtime :: Maven</name>
 
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-dependency-plugin</artifactId>
-        <configuration>
-          <copyPom>true</copyPom>
-          <useRepositoryLayout>true</useRepositoryLayout>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
-
   <dependencies>
 
     <!-- ****************************** -->
@@ -138,4 +125,60 @@
     </dependency>
   </dependencies>
 
+  <profiles>
+    <profile>
+      <id>local-settings</id>
+      <properties>
+        <image.repository.directory/>
+      </properties>
+      <build>
+        <pluginManagement>
+          <plugins>
+            <!-- Provides a settings.xml for Maven that will exclusively use the local Maven repository
+            of this machine. This way we can copy all dependencies to the Maven repository that lives in
+            the S2I image by using the go-offline Maven plugin -->
+            <plugin>
+              <artifactId>maven-resources-plugin</artifactId>
+              <configuration>
+                <outputDirectory>${project.build.directory}</outputDirectory>
+                <resources>
+                  <resource>
+                    <directory>settings</directory>
+                    <includes>
+                      <include>settings_local.xml</include>
+                    </includes>
+                    <filtering>true</filtering>
+                  </resource>
+                </resources>
+              </configuration>
+            </plugin>
+
+            <!--
+              This removes some of the tracking files Maven puts in the repository we created for the S2I image.
+              Otherwise Maven will try to resolve using the repositories we used to download these (namely the
+              local repository used in the `settings_local.xml`), that will not resolve to anything meaningful
+              when we do a build in the S2I image.
+            -->
+            <plugin>
+              <artifactId>maven-clean-plugin</artifactId>
+              <configuration>
+                <excludeDefaultDirectories>true</excludeDefaultDirectories>
+                <filesets>
+                  <fileset>
+                    <directory>${image.repository.directory}</directory>
+                    <followSymlinks>false</followSymlinks>
+                    <includes>
+                      <include>**/_remote.repositories</include>
+                      <include>**/resolver-status.properties</include>
+                      <include>**/*.lastUpdated</include>
+                    </includes>
+                  </fileset>
+                </filesets>
+              </configuration>
+            </plugin>
+          </plugins>
+        </pluginManagement>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/java/runtime/yaks-runtime-maven/settings/settings_local.xml
+++ b/java/runtime/yaks-runtime-maven/settings/settings_local.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements. See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <profiles>
+    <profile>
+      <id>local-repository</id>
+      <repositories>
+        <repository>
+          <id>local-repository</id>
+          <url>file://@settings.localRepository@</url>
+          <releases>
+            <enabled>true</enabled>
+            <updatePolicy>never</updatePolicy>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+            <updatePolicy>never</updatePolicy>
+          </snapshots>
+        </repository>
+      </repositories>
+      <pluginRepositories>
+        <pluginRepository>
+          <id>local-repository</id>
+          <url>file://@settings.localRepository@</url>
+          <releases>
+            <enabled>true</enabled>
+            <updatePolicy>never</updatePolicy>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+            <updatePolicy>never</updatePolicy>
+          </snapshots>
+        </pluginRepository>
+      </pluginRepositories>
+    </profile>
+  </profiles>
+
+  <activeProfiles>
+    <activeProfile>local-repository</activeProfile>
+  </activeProfiles>
+
+</settings>


### PR DESCRIPTION
Make sure to load dependencies from local repository first. Using go-offline Maven plugin to grab all required artifacts and plugins in the first place