### PR TITLE
Several fixes and update to Citrus 3.0.0-M2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -122,4 +122,4 @@ jobs:
         docker login $DOCKER_REGISTRY -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
     - name: Build
       run: |
-        make IMAGE_NAME=$IMAGE_NAME clean release-snapshot
+        make IMAGE_NAME=$IMAGE_NAME release-snapshot

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -78,7 +78,7 @@ jobs:
         docker login $DOCKER_REGISTRY -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
     - name: Build
       run: |
-        make VERSION=$VERSION IMAGE_NAME=$IMAGE_NAME clean release-snapshot
+        make VERSION=$VERSION IMAGE_NAME=$IMAGE_NAME release-snapshot
     - name: Check
       run: ls -l
     - name: Create Release

--- a/Makefile
+++ b/Makefile
@@ -124,11 +124,8 @@ git-tag:
 cross-compile:
 	./script/cross_compile.sh $(VERSION) '$(GOFLAGS)'
 
-docker-image: build-yaks
-	mkdir -p build/_output/bin
-	#operator-sdk build --image-builder docker $(IMAGE_NAME):$(VERSION)
-	cp yaks build/_output/bin
-	docker build -t $(IMAGE_NAME):$(VERSION) -f build/Dockerfile .
+docker-image:
+	./script/docker-build.sh $(IMAGE_NAME):$(VERSION)
 
 images-no-test: build package-artifacts-no-test docker-image
 

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -42,7 +42,7 @@
     <spring.version>5.2.8.RELEASE</spring.version>
     <cucumber.version>5.7.0</cucumber.version>
     <camel.version>3.5.0</camel.version>
-    <jackson.version>2.11.2</jackson.version>
+    <jackson.version>2.11.3</jackson.version>
     <junit.version>4.13.1</junit.version>
     <kubernetes-client.version>4.10.3</kubernetes-client.version>
     <knative-client.version>4.10.3</knative-client.version>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -37,11 +37,11 @@
     <maven.compiler.target>1.8</maven.compiler.target>
     <slf4j.version>1.7.30</slf4j.version>
     <log4j2.version>2.13.3</log4j2.version>
-    <groovy.version>2.5.0</groovy.version>
-    <citrus.version>3.0.0-M1</citrus.version>
-    <spring.version>5.2.4.RELEASE</spring.version>
-    <cucumber.version>5.4.2</cucumber.version>
-    <camel.version>3.1.0</camel.version>
+    <groovy.version>2.5.13</groovy.version>
+    <citrus.version>3.0.0-M2</citrus.version>
+    <spring.version>5.2.8.RELEASE</spring.version>
+    <cucumber.version>5.7.0</cucumber.version>
+    <camel.version>3.5.0</camel.version>
     <jackson.version>2.11.2</jackson.version>
     <junit.version>4.13.1</junit.version>
     <kubernetes-client.version>4.10.3</kubernetes-client.version>
@@ -51,9 +51,9 @@
     <apicurio.version>1.1.2</apicurio.version>
     <assertj-core.version>3.14.0</assertj-core.version>
     <s3-storage-wagon.version>2.3</s3-storage-wagon.version>
-    <activemq.version>5.15.11</activemq.version>
+    <activemq.version>5.16.0</activemq.version>
     <activemq.artemis.version>2.10.1</activemq.artemis.version>
-    <mockito.version>3.3.3</mockito.version>
+    <mockito.version>3.5.10</mockito.version>
 
     <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
     <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
@@ -107,7 +107,7 @@
       </dependency>
       <dependency>
         <groupId>com.consol.citrus</groupId>
-        <artifactId>citrus-core-spring</artifactId>
+        <artifactId>citrus-spring</artifactId>
         <version>${citrus.version}</version>
       </dependency>
       <dependency>

--- a/java/runtime/yaks-runtime-maven/pom.xml
+++ b/java/runtime/yaks-runtime-maven/pom.xml
@@ -100,6 +100,10 @@
 
     <dependency>
       <groupId>com.consol.citrus</groupId>
+      <artifactId>citrus-spring</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.consol.citrus</groupId>
       <artifactId>citrus-validation-json</artifactId>
     </dependency>
     <dependency>
@@ -112,15 +116,9 @@
     <!-- OTHERS                         -->
     <!--                                -->
     <!-- ****************************** -->
-
     <dependency>
       <groupId>io.cucumber</groupId>
       <artifactId>cucumber-junit</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.consol.citrus</groupId>
-      <artifactId>citrus-core-spring</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/java/steps/yaks-camel-k/pom.xml
+++ b/java/steps/yaks-camel-k/pom.xml
@@ -91,7 +91,7 @@
     </dependency>
     <dependency>
       <groupId>com.consol.citrus</groupId>
-      <artifactId>citrus-core-spring</artifactId>
+      <artifactId>citrus-spring</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/java/steps/yaks-camel-k/src/main/java/org/citrusframework/yaks/camelk/actions/integration/VerifyIntegrationAction.java
+++ b/java/steps/yaks-camel-k/src/main/java/org/citrusframework/yaks/camelk/actions/integration/VerifyIntegrationAction.java
@@ -19,6 +19,7 @@ package org.citrusframework.yaks.camelk.actions.integration;
 
 import com.consol.citrus.context.TestContext;
 import com.consol.citrus.exceptions.ActionTimeoutException;
+import com.consol.citrus.exceptions.CitrusRuntimeException;
 import io.fabric8.kubernetes.api.model.ContainerStatus;
 import io.fabric8.kubernetes.api.model.DoneablePod;
 import io.fabric8.kubernetes.api.model.Pod;
@@ -85,7 +86,9 @@ public class VerifyIntegrationAction extends AbstractCamelKAction {
             }
         }
 
-        throw new ActionTimeoutException(String.format("Failed to verify integration '%s' - has not printed message '%s' after %d attempts", name, logMessage, maxAttempts));
+        throw new ActionTimeoutException((maxAttempts * delayBetweenAttempts),
+                new CitrusRuntimeException(String.format("Failed to verify integration '%s' - " +
+                        "has not printed message '%s' after %d attempts", name, logMessage, maxAttempts)));
     }
 
     /**
@@ -133,7 +136,9 @@ public class VerifyIntegrationAction extends AbstractCamelKAction {
             }
         }
 
-        throw new ActionTimeoutException(String.format("Failed to verify integration '%s' - is not running after %d attempts", name, maxAttempts));
+        throw new ActionTimeoutException((maxAttempts * delayBetweenAttempts),
+                new CitrusRuntimeException(String.format("Failed to verify integration '%s' - " +
+                        "is not running after %d attempts", name, maxAttempts)));
     }
 
     /**

--- a/java/steps/yaks-camel/pom.xml
+++ b/java/steps/yaks-camel/pom.xml
@@ -67,6 +67,12 @@
 
     <!-- Test scope -->
     <dependency>
+      <groupId>org.citrusframework.yaks</groupId>
+      <artifactId>yaks-standard</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>io.cucumber</groupId>
       <artifactId>cucumber-junit</artifactId>
       <scope>test</scope>
@@ -78,7 +84,7 @@
     </dependency>
     <dependency>
       <groupId>com.consol.citrus</groupId>
-      <artifactId>citrus-core-spring</artifactId>
+      <artifactId>citrus-spring</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/java/steps/yaks-camel/src/test/java/org/citrusframework/yaks/camel/CamelFeatureTest.java
+++ b/java/steps/yaks-camel/src/test/java/org/citrusframework/yaks/camel/CamelFeatureTest.java
@@ -27,6 +27,7 @@ import org.junit.runner.RunWith;
 @RunWith(Cucumber.class)
 @CucumberOptions(
         strict = true,
+        extraGlue = { "org.citrusframework.yaks.standard" },
         plugin = { "pretty", "com.consol.citrus.cucumber.CitrusReporter" }
 )
 public class CamelFeatureTest {

--- a/java/steps/yaks-camel/src/test/resources/org/citrusframework/yaks/camel/camel-route-groovy.feature
+++ b/java/steps/yaks-camel/src/test/resources/org/citrusframework/yaks/camel/camel-route-groovy.feature
@@ -1,10 +1,11 @@
 Feature: Camel groovy route
 
   Background:
+    Given variable logLevel is "INFO"
     Given Camel route hello.groovy
     """
     from("direct:hello")
-     .to("log:org.citrusframework.yaks.camel?level=INFO")
+     .to("log:org.citrusframework.yaks.camel?level=${logLevel}")
      .split(body().tokenize(" "))
        .to("seda:tokens")
      .end()

--- a/java/steps/yaks-groovy/pom.xml
+++ b/java/steps/yaks-groovy/pom.xml
@@ -82,7 +82,7 @@
     </dependency>
     <dependency>
       <groupId>com.consol.citrus</groupId>
-      <artifactId>citrus-core-spring</artifactId>
+      <artifactId>citrus-spring</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/java/steps/yaks-groovy/src/main/java/org/citrusframework/yaks/groovy/GroovyScriptSteps.java
+++ b/java/steps/yaks-groovy/src/main/java/org/citrusframework/yaks/groovy/GroovyScriptSteps.java
@@ -26,6 +26,7 @@ import com.consol.citrus.Citrus;
 import com.consol.citrus.TestCaseRunner;
 import com.consol.citrus.annotations.CitrusFramework;
 import com.consol.citrus.annotations.CitrusResource;
+import com.consol.citrus.common.InitializingPhase;
 import com.consol.citrus.context.TestContext;
 import com.consol.citrus.endpoint.Endpoint;
 import com.consol.citrus.exceptions.CitrusRuntimeException;
@@ -38,7 +39,6 @@ import org.citrusframework.yaks.groovy.dsl.ConfigurationScript;
 import org.citrusframework.yaks.groovy.dsl.actions.ActionScript;
 import org.citrusframework.yaks.groovy.dsl.endpoints.EndpointConfigurationScript;
 import org.codehaus.groovy.control.customizers.ImportCustomizer;
-import org.springframework.beans.factory.InitializingBean;
 import org.springframework.core.io.Resource;
 
 /**
@@ -78,12 +78,8 @@ public class GroovyScriptSteps {
     public void createEndpoint(String name, String configurationScript) {
         Endpoint endpoint = new EndpointConfigurationScript(configurationScript).get();
 
-        if (endpoint instanceof InitializingBean) {
-            try {
-                ((InitializingBean) endpoint).afterPropertiesSet();
-            } catch (Exception e) {
-                throw new CitrusRuntimeException(String.format("Failed to initialize endpoint %s", name), e);
-            }
+        if (endpoint instanceof InitializingPhase) {
+            ((InitializingPhase) endpoint).initialize();
         }
 
         citrus.getCitrusContext().bind(name, endpoint);

--- a/java/steps/yaks-groovy/src/main/java/org/citrusframework/yaks/groovy/dsl/EndpointsConfiguration.java
+++ b/java/steps/yaks-groovy/src/main/java/org/citrusframework/yaks/groovy/dsl/EndpointsConfiguration.java
@@ -20,14 +20,13 @@ package org.citrusframework.yaks.groovy.dsl;
 import java.util.function.Supplier;
 
 import com.consol.citrus.Citrus;
+import com.consol.citrus.common.InitializingPhase;
 import com.consol.citrus.endpoint.Endpoint;
 import groovy.lang.Closure;
 import groovy.lang.GroovyObjectSupport;
 import groovy.lang.MissingMethodException;
-import groovy.lang.MissingPropertyException;
 import org.citrusframework.yaks.groovy.dsl.endpoints.EndpointConfiguration;
 import org.citrusframework.yaks.groovy.dsl.endpoints.Endpoints;
-import org.springframework.beans.factory.InitializingBean;
 
 /**
  * @author Christoph Deppisch
@@ -47,12 +46,8 @@ public class EndpointsConfiguration extends GroovyObjectSupport {
         callable.call();
 
         Endpoint endpoint = endpointSupplier.get();
-        if (endpoint instanceof InitializingBean) {
-            try {
-                ((InitializingBean) endpoint).afterPropertiesSet();
-            } catch (Exception e) {
-                throw new MissingPropertyException(type, this.getClass());
-            }
+        if (endpoint instanceof InitializingPhase) {
+            ((InitializingPhase) endpoint).initialize();
         }
         citrus.getCitrusContext().bind(endpoint.getName(), endpoint);
 

--- a/java/steps/yaks-groovy/src/main/java/org/citrusframework/yaks/groovy/dsl/QueueConfiguration.java
+++ b/java/steps/yaks-groovy/src/main/java/org/citrusframework/yaks/groovy/dsl/QueueConfiguration.java
@@ -32,6 +32,6 @@ public class QueueConfiguration {
     }
 
     public void queue(String name) {
-        citrus.getCitrusContext().bind(name, new DefaultMessageQueue());
+        citrus.getCitrusContext().bind(name, new DefaultMessageQueue(name));
     }
 }

--- a/java/steps/yaks-groovy/src/main/java/org/citrusframework/yaks/groovy/dsl/beans/BeansConfiguration.java
+++ b/java/steps/yaks-groovy/src/main/java/org/citrusframework/yaks/groovy/dsl/beans/BeansConfiguration.java
@@ -37,7 +37,7 @@ public class BeansConfiguration extends GroovyObjectSupport {
     }
 
     public void queue(String name) {
-        citrus.getCitrusContext().bind(name, new DefaultMessageQueue());
+        citrus.getCitrusContext().bind(name, new DefaultMessageQueue(name));
     }
 
     public void propertyMissing(String name, Object value) {

--- a/java/steps/yaks-http/pom.xml
+++ b/java/steps/yaks-http/pom.xml
@@ -56,7 +56,7 @@
     </dependency>
     <dependency>
       <groupId>com.consol.citrus</groupId>
-      <artifactId>citrus-core-spring</artifactId>
+      <artifactId>citrus-spring</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/java/steps/yaks-http/src/main/java/org/citrusframework/yaks/http/HttpClientSteps.java
+++ b/java/steps/yaks-http/src/main/java/org/citrusframework/yaks/http/HttpClientSteps.java
@@ -55,6 +55,7 @@ import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.util.StringUtils;
 
 import static com.consol.citrus.http.actions.HttpActionBuilder.http;
+import static com.consol.citrus.validation.PathExpressionValidationContext.Builder.pathExpression;
 
 /**
  * @author Christoph Deppisch
@@ -75,7 +76,7 @@ public class HttpClientSteps implements HttpSteps {
     private Map<String, String> responseHeaders = new HashMap<>();
     private Map<String, String> requestParams = new HashMap<>();
 
-    private Map<String, String> bodyValidationExpressions = new HashMap<>();
+    private Map<String, Object> bodyValidationExpressions = new HashMap<>();
 
     private String requestMessageType;
     private String responseMessageType;
@@ -320,9 +321,7 @@ public class HttpClientSteps implements HttpSteps {
                 .response(response.getStatusCode())
                 .message(response);
 
-        for (Map.Entry<String, String> headerEntry : bodyValidationExpressions.entrySet()) {
-            responseBuilder.validate(headerEntry.getKey(), headerEntry.getValue());
-        }
+        responseBuilder.validate(pathExpression().expressions(bodyValidationExpressions));
         bodyValidationExpressions.clear();
 
         responseBuilder.timeout(timeout);

--- a/java/steps/yaks-http/src/main/java/org/citrusframework/yaks/http/HttpClientSteps.java
+++ b/java/steps/yaks-http/src/main/java/org/citrusframework/yaks/http/HttpClientSteps.java
@@ -89,13 +89,17 @@ public class HttpClientSteps implements HttpSteps {
 
     private long timeout;
 
+    private boolean forkMode = HttpSettings.getForkMode();
+
     @Before
     public void before(Scenario scenario) {
         if (httpClient == null) {
             if (citrus.getCitrusContext().getReferenceResolver().resolveAll(HttpClient.class).size() == 1L) {
                 httpClient = citrus.getCitrusContext().getReferenceResolver().resolve(HttpClient.class);
             } else {
-                httpClient = new HttpClientBuilder().build();
+                httpClient = new HttpClientBuilder()
+                        .timeout(HttpSettings.getTimeout())
+                        .build();
             }
         }
 
@@ -134,6 +138,11 @@ public class HttpClientSteps implements HttpSteps {
     @Given("^HTTP request timeout is (\\d+)(?: ms| milliseconds)$")
     public void configureTimeout(long timeout) {
         this.timeout = timeout;
+    }
+
+    @Given("^HTTP request fork mode is (enabled|disabled)$")
+    public void configureForkMode(String mode) {
+        this.forkMode = "enabled".equals(mode);
     }
 
     @Given("^(?:URL|url) is healthy$")
@@ -298,6 +307,8 @@ public class HttpClientSteps implements HttpSteps {
         } else {
             requestBuilder = sendBuilder.post().message(request);
         }
+
+        requestBuilder.fork(forkMode);
 
         if (StringUtils.hasText(requestUrl)) {
             requestBuilder.uri(requestUrl);

--- a/java/steps/yaks-http/src/main/java/org/citrusframework/yaks/http/HttpServerSteps.java
+++ b/java/steps/yaks-http/src/main/java/org/citrusframework/yaks/http/HttpServerSteps.java
@@ -40,6 +40,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 
 import static com.consol.citrus.http.actions.HttpActionBuilder.http;
+import static com.consol.citrus.validation.PathExpressionValidationContext.Builder.pathExpression;
 
 /**
  * @author Christoph Deppisch
@@ -58,7 +59,7 @@ public class HttpServerSteps implements HttpSteps {
     private Map<String, String> responseHeaders = new HashMap<>();
     private Map<String, String> requestParams = new HashMap<>();
 
-    private Map<String, String> bodyValidationExpressions = new HashMap<>();
+    private Map<String, Object> bodyValidationExpressions = new HashMap<>();
 
     private String requestMessageType;
     private String responseMessageType;
@@ -90,11 +91,7 @@ public class HttpServerSteps implements HttpSteps {
                         .build();
 
                 citrus.getCitrusContext().getReferenceResolver().bind(serverName, httpServer);
-                try {
-                    httpServer.afterPropertiesSet();
-                } catch (Exception e) {
-                    throw new IllegalStateException("Failed to initialize Http server", e);
-                }
+                httpServer.initialize();
             }
         }
 
@@ -264,9 +261,7 @@ public class HttpServerSteps implements HttpSteps {
             requestBuilder = receiveBuilder.post().message(request);
         }
 
-        for (Map.Entry<String, String> headerEntry : bodyValidationExpressions.entrySet()) {
-            requestBuilder.validate(headerEntry.getKey(), headerEntry.getValue());
-        }
+        requestBuilder.validate(pathExpression().expressions(bodyValidationExpressions));
         bodyValidationExpressions.clear();
 
         requestBuilder

--- a/java/steps/yaks-http/src/main/java/org/citrusframework/yaks/http/HttpSettings.java
+++ b/java/steps/yaks-http/src/main/java/org/citrusframework/yaks/http/HttpSettings.java
@@ -29,6 +29,10 @@ public class HttpSettings {
     private static final String TIMEOUT_ENV = HTTP_ENV_PREFIX + "_TIMEOUT";
     private static final String TIMEOUT_DEFAULT = "2000";
 
+    private static final String FORK_MODE_PROPERTY = HTTP_PROPERTY_PREFIX + ".fork.mode";
+    private static final String FORK_MODE_ENV = HTTP_ENV_PREFIX + "_FORK_MODE";
+    private static final String FORK_MODE_DEFAULT = "false";
+
     private static final String SERVER_NAME_PROPERTY = HTTP_PROPERTY_PREFIX + "server.name";
     private static final String SERVER_NAME_ENV = HTTP_ENV_PREFIX + "SERVER_NAME";
     private static final String SERVER_NAME_DEFAULT = "yaks-http-server";
@@ -48,6 +52,15 @@ public class HttpSettings {
     public static long getTimeout() {
         return Long.parseLong(System.getProperty(TIMEOUT_PROPERTY,
                 System.getenv(TIMEOUT_ENV) != null ? System.getenv(TIMEOUT_ENV) : TIMEOUT_DEFAULT));
+    }
+
+    /**
+     * Request fork mode when sending messages.
+     * @return
+     */
+    public static boolean getForkMode() {
+        return Boolean.parseBoolean(System.getProperty(FORK_MODE_PROPERTY,
+                System.getenv(FORK_MODE_ENV) != null ? System.getenv(FORK_MODE_ENV) : FORK_MODE_DEFAULT));
     }
 
     /**

--- a/java/steps/yaks-jdbc/pom.xml
+++ b/java/steps/yaks-jdbc/pom.xml
@@ -52,7 +52,7 @@
     </dependency>
     <dependency>
       <groupId>com.consol.citrus</groupId>
-      <artifactId>citrus-core-spring</artifactId>
+      <artifactId>citrus-spring</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/java/steps/yaks-jms/pom.xml
+++ b/java/steps/yaks-jms/pom.xml
@@ -70,7 +70,7 @@
     </dependency>
     <dependency>
       <groupId>com.consol.citrus</groupId>
-      <artifactId>citrus-core-spring</artifactId>
+      <artifactId>citrus-spring</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/java/steps/yaks-kafka/pom.xml
+++ b/java/steps/yaks-kafka/pom.xml
@@ -63,7 +63,7 @@
     </dependency>
     <dependency>
       <groupId>com.consol.citrus</groupId>
-      <artifactId>citrus-core-spring</artifactId>
+      <artifactId>citrus-spring</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/java/steps/yaks-knative/pom.xml
+++ b/java/steps/yaks-knative/pom.xml
@@ -78,7 +78,7 @@
     </dependency>
     <dependency>
       <groupId>com.consol.citrus</groupId>
-      <artifactId>citrus-core-spring</artifactId>
+      <artifactId>citrus-spring</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/java/steps/yaks-kubernetes/pom.xml
+++ b/java/steps/yaks-kubernetes/pom.xml
@@ -73,7 +73,7 @@
     </dependency>
     <dependency>
       <groupId>com.consol.citrus</groupId>
-      <artifactId>citrus-core-spring</artifactId>
+      <artifactId>citrus-spring</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/java/steps/yaks-kubernetes/src/main/java/org/citrusframework/yaks/kubernetes/KubernetesSteps.java
+++ b/java/steps/yaks-kubernetes/src/main/java/org/citrusframework/yaks/kubernetes/KubernetesSteps.java
@@ -75,11 +75,7 @@ public class KubernetesSteps {
                     .build();
 
             citrus.getCitrusContext().getReferenceResolver().bind(serviceName, httpServer);
-            try {
-                httpServer.afterPropertiesSet();
-            } catch (Exception e) {
-                throw new IllegalStateException("Failed to initialize Http server as Knative service", e);
-            }
+            httpServer.initialize();
         }
 
         if (k8sClient == null) {

--- a/java/steps/yaks-openapi/pom.xml
+++ b/java/steps/yaks-openapi/pom.xml
@@ -68,7 +68,7 @@
     </dependency>
     <dependency>
       <groupId>com.consol.citrus</groupId>
-      <artifactId>citrus-core-spring</artifactId>
+      <artifactId>citrus-spring</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/java/steps/yaks-openapi/src/main/java/org/citrusframework/yaks/openapi/OpenApiResourceLoader.java
+++ b/java/steps/yaks-openapi/src/main/java/org/citrusframework/yaks/openapi/OpenApiResourceLoader.java
@@ -30,9 +30,12 @@ import java.util.Objects;
 import com.consol.citrus.util.FileUtils;
 import io.apicurio.datamodels.Library;
 import io.apicurio.datamodels.openapi.models.OasDocument;
+import org.apache.http.HttpHeaders;
 import org.apache.http.conn.ssl.NoopHostnameVerifier;
 import org.apache.http.conn.ssl.TrustAllStrategy;
 import org.apache.http.ssl.SSLContexts;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
 
 /**
  * Loads Open API specifications from different locations like file resource or web resource.
@@ -69,7 +72,8 @@ public final class OpenApiResourceLoader {
         HttpURLConnection con = null;
         try {
             con = (HttpURLConnection) url.openConnection();
-            con.setRequestMethod("GET");
+            con.setRequestMethod(HttpMethod.GET.name());
+            con.setRequestProperty(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE);
 
             int status = con.getResponseCode();
             if (status > 299) {
@@ -106,7 +110,8 @@ public final class OpenApiResourceLoader {
             HttpsURLConnection.setDefaultHostnameVerifier(NoopHostnameVerifier.INSTANCE);
 
             con = (HttpsURLConnection) url.openConnection();
-            con.setRequestMethod("GET");
+            con.setRequestMethod(HttpMethod.GET.name());
+            con.setRequestProperty(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE);
 
             int status = con.getResponseCode();
             if (status > 299) {

--- a/java/steps/yaks-openapi/src/main/java/org/citrusframework/yaks/openapi/OpenApiSteps.java
+++ b/java/steps/yaks-openapi/src/main/java/org/citrusframework/yaks/openapi/OpenApiSteps.java
@@ -176,12 +176,12 @@ public class OpenApiSteps {
         if (operation.parameters != null) {
             operation.parameters.stream()
                     .filter(param -> "header".equals(param.in))
-                    .filter(param -> param.required)
+                    .filter(param -> param.required != null && param.required)
                     .forEach(param -> clientSteps.addRequestHeader(param.getName(), OpenApiTestDataGenerator.createRandomValueExpression((OasSchema) param.schema, OasModelHelper.getSchemaDefinitions(openApiDoc), false)));
 
             operation.parameters.stream()
                     .filter(param -> "query".equals(param.in))
-                    .filter(param -> param.required)
+                    .filter(param -> param.required != null && param.required)
                     .forEach(param -> clientSteps.addRequestQueryParam(param.getName(), OpenApiTestDataGenerator.createRandomValueExpression((OasSchema) param.schema)));
         }
 

--- a/java/steps/yaks-openapi/src/main/java/org/citrusframework/yaks/openapi/OpenApiSteps.java
+++ b/java/steps/yaks-openapi/src/main/java/org/citrusframework/yaks/openapi/OpenApiSteps.java
@@ -114,6 +114,11 @@ public class OpenApiSteps {
         }
     }
 
+    @Given("^OpenAPI request fork mode is (enabled|disabled)$")
+    public void configureForkMode(String mode) {
+        clientSteps.configureForkMode(mode);
+    }
+
     @Given("^outbound dictionary$")
     public void createOutboundDictionary(DataTable dataTable) {
         Map<String, String> mappings = dataTable.asMap(String.class, String.class);

--- a/java/steps/yaks-standard/pom.xml
+++ b/java/steps/yaks-standard/pom.xml
@@ -60,7 +60,7 @@
     </dependency>
     <dependency>
       <groupId>com.consol.citrus</groupId>
-      <artifactId>citrus-core-spring</artifactId>
+      <artifactId>citrus-spring</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/java/steps/yaks-standard/src/main/java/org/citrusframework/yaks/standard/ComponentSteps.java
+++ b/java/steps/yaks-standard/src/main/java/org/citrusframework/yaks/standard/ComponentSteps.java
@@ -32,6 +32,6 @@ public class ComponentSteps {
 
     @Given("^(?:create|new) message queue ([^\"\\s]+)$")
     public void createMessageQueue(String name) {
-        citrus.getCitrusContext().getReferenceResolver().bind(name, new DefaultMessageQueue());
+        citrus.getCitrusContext().getReferenceResolver().bind(name, new DefaultMessageQueue(name));
     }
 }

--- a/java/steps/yaks-standard/src/test/java/org/citrusframework/yaks/standard/EndpointConfiguration.java
+++ b/java/steps/yaks-standard/src/test/java/org/citrusframework/yaks/standard/EndpointConfiguration.java
@@ -26,6 +26,7 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.spring.SpringCamelContext;
 import org.citrusframework.yaks.report.SystemOutTestReporter;
 import org.springframework.beans.factory.BeanCreationException;
+import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.DependsOn;
@@ -36,7 +37,7 @@ import org.springframework.context.annotation.DependsOn;
 @Configuration
 public class EndpointConfiguration {
 
-    private CamelContext camelContext = new SpringCamelContext();
+    private CamelContext camelContext;
 
     @Bean
     public DirectEndpoint fooEndpoint() {
@@ -57,8 +58,9 @@ public class EndpointConfiguration {
     }
 
     @Bean
-    public CamelContext camelContext() {
-        RouteBuilder routeBuilder = new RouteBuilder() {
+    public CamelContext camelContext(ApplicationContext applicationContext) {
+        camelContext = new SpringCamelContext(applicationContext);
+        RouteBuilder routeBuilder = new RouteBuilder(camelContext) {
             @Override
             public void configure() throws Exception {
                 from("direct:echo")

--- a/pkg/cmd/test.go
+++ b/pkg/cmd/test.go
@@ -325,13 +325,17 @@ func (o *testCmdOptions) createTempNamespace(runConfig *config.RunConfig, c clie
 		// looking for operator in cluster-wide operator namespace
 		if operatorNamespace, namespaceErr := getDefaultOperatorNamespace(c, runConfig); namespaceErr == nil {
 			operator, err = o.findOperator(c, operatorNamespace)
+			if err != nil {
+				return namespace, err
+			}
 		} else {
 			return namespace, namespaceErr
 		}
+	} else if err != nil {
+		return namespace, err
 	}
 
-
-	if err == nil && isOperatorGlobal(operator) {
+	if isOperatorGlobal(operator) {
 		// Using global operator to manage temporary namespaces, no action required
 		return namespace, nil
 	}

--- a/script/check_licenses.sh
+++ b/script/check_licenses.sh
@@ -52,7 +52,6 @@ check_licenses() {
   fi
 }
 
-
 check_licenses *.go ./script/headers/default.txt
 check_licenses *.groovy ./script/headers/default-jvm.txt
 check_licenses *.java ./script/headers/default-jvm.txt

--- a/script/docker-build.sh
+++ b/script/docker-build.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+if [ "$#" -ne 1 ]; then
+    echo "usage: $0 image:version"
+    exit 1
+fi
+
+location=$(dirname $0)
+image=$1
+
+cd $location/..
+
+mkdir -p build/_output/bin
+GOOS=linux go build $(GOFLAGS) -o build/_output/bin/yaks ./cmd/manager/*.go
+docker build -t $image -f build/Dockerfile .

--- a/script/set_version.sh
+++ b/script/set_version.sh
@@ -46,21 +46,20 @@ java_sources=${location}/../java
 
 blacklist=("./java/.mvn/wrapper" "./java/.idea" ".DS_Store" "/target/")
 
-for f in $(find ${java_sources} -type f);
-do
+find ${java_sources} -type f -print0 | while IFS= read -r -d '' file; do
   check=true
   for b in ${blacklist[*]}; do
-    if [[ "$f" == *"$b"* ]]; then
-      #echo "skip $f"
+    if [[ "$file" == *"$b"* ]]; then
+      #echo "skip $file"
       check=false
     fi
   done
   if [ "$check" = true ]; then
     if [[ "$OSTYPE" == "linux-gnu"* ]]; then
-      sed -i "s/$snapshot_version/$version/g" $f
+      sed -i "s/$snapshot_version/$version/g" $file
     elif [[ "$OSTYPE" == "darwin"* ]]; then
       # Mac OSX
-      sed -i '' "s/$snapshot_version/$version/g" $f
+      sed -i '' "s/$snapshot_version/$version/g" $file
     fi
   fi
 done


### PR DESCRIPTION
- fix(#176): Update to Citrus 3.0.0-M2
- fix(#172): Make sure to not loose any errors while finding the operator
- fix(#183): Fix Docker image build on MacOS
- fix(#166): Fix set_versions release script
- chore: Load Open API data dictionary from file
- fix: Nullpointer when required field is missing on Open API query/path parameter
- fix: Add fork mode when sending Http client requests
- chore: Bump jackson version to 2.11.3

Fixes #176 #172 #183 #166 