### PR TITLE
chore: Use the citrusframework organization for pushing Docker images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ VERSION := 0.1.0-SNAPSHOT
 SNAPSHOT_VERSION := 0.1.0-SNAPSHOT
 LAST_RELEASED_VERSION := 0.1.0
 LOCAL_REPOSITORY := /tmp/artifacts/m2
-IMAGE_NAME := docker.io/yaks/yaks
+IMAGE_NAME := docker.io/citrusframework/yaks
 RELEASE_GIT_REMOTE := upstream
 GIT_COMMIT := $(shell git rev-list -1 HEAD)
 

--- a/deploy/olm-catalog/yaks/0.1.0-snapshot/yaks.v0.1.0-snapshot.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/yaks/0.1.0-snapshot/yaks.v0.1.0-snapshot.clusterserviceversion.yaml
@@ -36,7 +36,7 @@ metadata:
     capabilities: Full Lifecycle
     categories: Integration & Delivery
     certified: "false"
-    containerImage: docker.io/yaks/yaks:0.1.0-SNAPSHOT
+    containerImage: docker.io/citrusframework/yaks:0.1.0-SNAPSHOT
     createdAt: "2020-09-25T02:45:00Z"
     description: YAKS is a platform to enable Cloud Native BDD testing on Kubernetes.
     repository: https://github.com/citrusframework/yaks
@@ -174,7 +174,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
-                image: docker.io/yaks/yaks:0.1.0-SNAPSHOT
+                image: docker.io/citrusframework/yaks:0.1.0-SNAPSHOT
                 imagePullPolicy: IfNotPresent
                 name: yaks-operator
                 resources: {}

--- a/deploy/operator-deployment.yaml
+++ b/deploy/operator-deployment.yaml
@@ -39,7 +39,7 @@ spec:
       serviceAccountName: yaks-operator
       containers:
         - name: yaks-operator
-          image: docker.io/yaks/yaks:0.1.0-SNAPSHOT
+          image: docker.io/citrusframework/yaks:0.1.0-SNAPSHOT
           command:
           - yaks
           - operator

--- a/pkg/util/defaults/defaults.go
+++ b/pkg/util/defaults/defaults.go
@@ -29,5 +29,5 @@ const (
 	LocalRepository = "/tmp/artifacts/m2"
 
 	// ImageName --
-	ImageName = "docker.io/yaks/yaks"
+	ImageName = "docker.io/citrusframework/yaks"
 )

--- a/script/util/version_funcs
+++ b/script/util/version_funcs
@@ -81,7 +81,7 @@ set_version() {
   local working_dir="$1"
   local version="$2"
   local snapshot_version="$3"
-  local image_name=${4:-docker.io\/yaks\/yaks}
+  local image_name=${4:-docker.io\/citrusframework\/yaks}
   local sanitized_image_name=${image_name//\//\\\/}
 
   if [[ "$version" == "$snapshot_version" ]]; then
@@ -94,10 +94,10 @@ set_version() {
   for f in $(find $working_dir/deploy -type f -name "*.yaml" | grep -v olm-catalog);
   do
     if [[ "$OSTYPE" == "linux-gnu"* ]]; then
-      sed -i -r "s/docker.io\/yaks\/yaks:([0-9]+[a-zA-Z0-9\-\.].*).*/${sanitized_image_name}:${version}/" $f
+      sed -i -r "s/docker.io\/citrusframework\/yaks:([0-9]+[a-zA-Z0-9\-\.].*).*/${sanitized_image_name}:${version}/" $f
     elif [[ "$OSTYPE" == "darwin"* ]]; then
       # Mac OSX
-      sed -i '' -E "s/docker.io\/yaks\/yaks:([0-9]+[a-zA-Z0-9\-\.].*).*/${sanitized_image_name}:${version}/" $f
+      sed -i '' -E "s/docker.io\/citrusframework\/yaks:([0-9]+[a-zA-Z0-9\-\.].*).*/${sanitized_image_name}:${version}/" $f
     fi
   done
 


### PR DESCRIPTION
Using the official citrusframework organization on DockerHub.io. The nightly and SNAPSHOT release builds keep using docker.io/yaks/yaks image though.