### PR TITLE
Make test timeout configurable and add suite errors to reporting

### DIFF
--- a/java/docs/cli.adoc
+++ b/java/docs/cli.adoc
@@ -9,6 +9,7 @@ Releases of the CLI are available on:
 - Github Releases: https://github.com/citrusfrmaework/yaks/releases
 - Homebrew (Mac and Linux): https://formulae.brew.sh/formula/yaks
 
+[[cli-commands]]
 == Available Commands
 
 Some of the most used commands are:
@@ -21,18 +22,95 @@ Some of the most used commands are:
 |Obtain the full list of available commands
 |`yaks help`
 
+|completion
+|Generates completion scripts (bash, zsh)
+|`yaks completion`
+
+|install
+|Install YAKS operator and setup cluster (roles, CRDs)
+|`yaks install`
+
 |test
 |Run a test on Kubernetes
 |`yaks test helloworld.feature`
 
+|report
+|Fetches and generates reports from test results
+|`yaks report --fetch -o junit`
+
+|upload
+|Upload custom artifacts (steps, extensions) to Minio storage
+|`yaks upload ./steps/my-custom-steps`
+
+|uninstall
+|Remove YAKS (operator, roles, CRDs, ...) from the cluster
+|`yaks uninstall`
+
+|version
+|Print current YAKS version
+|`yaks version`
+
 |===
 
 The list above is not the full list of available commands. You can run `yaks help` to obtain the full list.
-And each command also takes `--help` as parameter to output more information:
+Each sub-command also takes `--help` as parameter to output more information on that specific command usage:
 
+.Overall help
+[source, shell script]
+----
+yaks help
+----
+
+[source]
+----
+YAKS is a platform to enable Cloud Native BDD testing on Kubernetes.
+
+Usage:
+  yaks [command]
+
+Available Commands:
+  completion  Generates completion scripts
+  help        Help about any command
+  install     Installs YAKS on a Kubernetes cluster
+  report      Generate test report from last test run
+  test        Execute a test on Kubernetes
+  uninstall   Uninstall YAKS from a Kubernetes cluster
+  upload      Upload a local test artifact to the cluster
+  version     Display version information
+
+Flags:
+      --config string      Path to the config file to use for CLI requests
+  -h, --help               help for yaks
+  -n, --namespace string   Namespace to use for all operations
+
+Use "yaks [command] --help" for more information about a command.
+----
+
+.Command help
 [source, shell script]
 ----
 yaks test --help
 ----
 
+[[cli-install]]
+== install
 
+The command `install` performs the YAKS installation on a target cluster. The command has two separate install steps:
+
+. Setup cluster resources (CRDs, roles, rolebindings)
+. Install YAKS operator to current namespace (or to the provided namespace in settings)
+
+[[cli-test]]
+== test
+
+[[cli-report]]
+== report
+
+[[cli-upload]]
+== upload
+
+[[cli-uninstall]]
+== uninstall
+
+[[cli-version]]
+== version

--- a/pkg/apis/yaks/v1alpha1/test_types.go
+++ b/pkg/apis/yaks/v1alpha1/test_types.go
@@ -145,6 +145,8 @@ const (
 
 	// TestPhaseNone
 	TestPhaseNone TestPhase = ""
+	// TestPhaseNew
+	TestPhaseNew TestPhase = "New"
 	// TestPhasePending
 	TestPhasePending TestPhase = "Pending"
 	// TestPhaseRunning
@@ -161,9 +163,16 @@ const (
 	TestPhaseUpdating TestPhase = "Updating"
 )
 
-func (phase TestPhase) AsError() error {
+func (phase TestPhase) AsError(name string) error {
+	if phase == TestPhaseNone ||
+		phase == TestPhaseNew ||
+		phase == TestPhasePending ||
+		phase == TestPhaseRunning {
+		return fmt.Errorf("test %s timed out with status: %s", name, string(phase))
+	}
+
 	if phase != TestPhasePassed {
-		return fmt.Errorf("Test %s", string(phase))
+		return fmt.Errorf("test %s finished with status: %s", name, string(phase))
 	}
 	return nil
 }

--- a/pkg/cmd/config/config.go
+++ b/pkg/cmd/config/config.go
@@ -27,6 +27,7 @@ import (
 const (
     OperatorNamespaceOpenShift  = "openshift-operators"
     OperatorNamespaceKubernetes = "kube-operators"
+    DefaultTimeout = "30m"
 )
 
 type RunConfig struct {
@@ -38,6 +39,7 @@ type RunConfig struct {
 
 type Config struct {
     Recursive bool            `yaml:"recursive"`
+    Timeout   string          `yaml:"timeout"`
     Namespace NamespaceConfig `yaml:"namespace"`
     Operator  OperatorConfig  `yaml:"operator"`
     Runtime   RuntimeConfig   `yaml:"runtime"`
@@ -116,7 +118,7 @@ func NewWithDefaults() *RunConfig {
         Temporary:  false,
     }
 
-    var config = Config {Recursive: true, Namespace: ns}
+    var config = Config {Recursive: true, Namespace: ns, Timeout: DefaultTimeout}
     return &RunConfig {Config: config, BaseDir: ""}
 }
 

--- a/pkg/cmd/report/junit.go
+++ b/pkg/cmd/report/junit.go
@@ -48,10 +48,18 @@ type TestCase struct {
 	Time float32 `xml:"time,attr"`
 	SystemOut string `xml:"system-out,omitempty"`
 	Failure *Failure
+	Error *Error
 }
 
 type Failure struct {
 	XMLName xml.Name `xml:"failure,omitempty"`
+	Message string `xml:"message,attr,omitempty"`
+	Type string `xml:"type,attr,omitempty"`
+	Stacktrace string `xml:",chardata"`
+}
+
+type Error struct {
+	XMLName xml.Name `xml:"error,omitempty"`
 	Message string `xml:"message,attr,omitempty"`
 	Type string `xml:"type,attr,omitempty"`
 	Stacktrace string `xml:",chardata"`
@@ -64,6 +72,7 @@ func createJUnitReport(results *v1alpha1.TestResults, outputDir string) (string,
 			Failures: results.Summary.Failed,
 			Skipped: results.Summary.Skipped,
 			Tests: results.Summary.Total,
+			Errors: len(results.Errors),
 		},
 	}
 
@@ -79,6 +88,21 @@ func createJUnitReport(results *v1alpha1.TestResults, outputDir string) (string,
 				Type:       result.ErrorType,
 				Stacktrace: "",
 			}
+		}
+
+		report.Suite.TestCase = append(report.Suite.TestCase, testCase)
+	}
+
+	for _, errorDetail := range results.Errors {
+		testCase := TestCase{
+			Name: "initializationError",
+			ClassName: "Runtime",
+		}
+
+		testCase.Error = &Error{
+			Message:    errorDetail,
+			Type:       "Error",
+			Stacktrace: "",
 		}
 
 		report.Suite.TestCase = append(report.Suite.TestCase, testCase)

--- a/pkg/cmd/report/report.go
+++ b/pkg/cmd/report/report.go
@@ -160,8 +160,8 @@ func PrintSummaryReport(results *v1alpha1.TestResults) {
 }
 
 func GetSummaryReport(results *v1alpha1.TestResults) string {
-	summary := fmt.Sprintf("Test results: Total: %d, Passed: %d, Failed: %d, Skipped: %d\n",
-		results.Summary.Total, results.Summary.Passed, results.Summary.Failed, results.Summary.Skipped)
+	summary := fmt.Sprintf("Test results: Total: %d, Passed: %d, Failed: %d, Errors: %d, Skipped: %d\n",
+		results.Summary.Total, results.Summary.Passed, results.Summary.Failed, len(results.Errors), results.Summary.Skipped)
 
 	for _, test := range results.Tests {
 		result := "Passed"
@@ -174,7 +174,7 @@ func GetSummaryReport(results *v1alpha1.TestResults) string {
 
 	if len(results.Errors) > 0 {
 		if prettyPrint, err := json.MarshalIndent(results.Errors, "", "  "); err == nil {
-			summary += fmt.Sprintf("\nErrors: \n%s", string(prettyPrint))
+			summary += fmt.Sprintf("\nErrors: %d\n%s", len(results.Errors), string(prettyPrint))
 		} else {
 			fmt.Printf("Failed to read error details from test results: %s", err.Error())
 		}

--- a/pkg/controller/test/initialize.go
+++ b/pkg/controller/test/initialize.go
@@ -42,7 +42,8 @@ func (action *initializeAction) Name() string {
 
 // CanHandle tells whether this action can handle the test
 func (action *initializeAction) CanHandle(build *v1alpha1.Test) bool {
-	return build.Status.Phase == v1alpha1.TestPhaseNone
+	return build.Status.Phase == v1alpha1.TestPhaseNone ||
+		build.Status.Phase == v1alpha1.TestPhaseNew
 }
 
 // Handle handles the test

--- a/pkg/controller/test/monitor.go
+++ b/pkg/controller/test/monitor.go
@@ -55,7 +55,7 @@ func (action *monitorAction) Handle(ctx context.Context, test *v1alpha1.Test) (*
 
 	if expectedDigest != test.Status.Digest {
 		// Restart the test
-		test.Status.Phase = v1alpha1.TestPhaseNone
+		test.Status.Phase = v1alpha1.TestPhaseNew
 	}
 
 	return test, nil


### PR DESCRIPTION
Fixes #207: Make test timeout configurable

Introduce test status phase "New" and improve error message for tests that hit a timeout.

Fixes #152: Add suite errors to reporting

Do not loose suite related errors (e.g. in prepare scripts) and add those errors to the reporting.