### PR TITLE
fix(#213): Do not fail on unrecognized fields in Kamelet model

### DIFF
--- a/java/steps/yaks-camel-k/src/main/java/org/citrusframework/yaks/camelk/model/KameletSpec.java
+++ b/java/steps/yaks-camel-k/src/main/java/org/citrusframework/yaks/camelk/model/KameletSpec.java
@@ -22,6 +22,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
@@ -217,6 +218,7 @@ public class KameletSpec implements KubernetesResource {
 
         @JsonInclude(JsonInclude.Include.NON_NULL)
         @JsonPropertyOrder({"title", "description", "type", "default", "example"})
+        @JsonIgnoreProperties(ignoreUnknown = true)
         public static class PropertyConfig {
             @JsonProperty("title")
             private String title;

--- a/java/steps/yaks-camel-k/src/test/java/org.citrusframework.yaks.camelk/KameletBuilderTest.java
+++ b/java/steps/yaks-camel-k/src/test/java/org.citrusframework.yaks.camelk/KameletBuilderTest.java
@@ -23,6 +23,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import com.consol.citrus.util.FileUtils;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.citrusframework.yaks.camelk.model.Kamelet;
 import org.citrusframework.yaks.camelk.model.KameletSpec;
 import org.citrusframework.yaks.kubernetes.KubernetesSupport;
@@ -63,5 +64,11 @@ public class KameletBuilderTest {
 		Assert.assertEquals(StringUtils.trimAllWhitespace(
 				FileUtils.readToString(new ClassPathResource("kamelet.json", KameletBuilderTest.class))),
 				StringUtils.trimAllWhitespace(json));
+	}
+
+	@Test
+	public void shouldDeserializeKamelet() throws IOException {
+		new ObjectMapper().readValue(
+				FileUtils.readToString(new ClassPathResource("timer-source.kamelet.json")), Kamelet.class);
 	}
 }

--- a/java/steps/yaks-camel-k/src/test/resources/timer-source.kamelet.json
+++ b/java/steps/yaks-camel-k/src/test/resources/timer-source.kamelet.json
@@ -1,0 +1,62 @@
+{
+  "apiVersion": "camel.apache.org/v1alpha1",
+  "kind": "Kamelet",
+  "metadata": {
+    "name": "timer-source",
+    "annotations": {
+      "camel.apache.org/kamelet.icon": "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4NCjwhLS0gU3ZnIFZlY3RvciBJY29ucyA6IGh0dHA6Ly93d3cub25saW5ld2ViZm9udHMuY29tL2ljb24gLS0+DQo8IURPQ1RZUEUgc3ZnIFBVQkxJQyAiLS8vVzNDLy9EVEQgU1ZHIDEuMS8vRU4iICJodHRwOi8vd3d3LnczLm9yZy9HcmFwaGljcy9TVkcvMS4xL0RURC9zdmcxMS5kdGQiPg0KPHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4IiB2aWV3Qm94PSIwIDAgMTAwMCAxMDAwIiBlbmFibGUtYmFja2dyb3VuZD0ibmV3IDAgMCAxMDAwIDEwMDAiIHhtbDpzcGFjZT0icHJlc2VydmUiPg0KPG1ldGFkYXRhPiBTdmcgVmVjdG9yIEljb25zIDogaHR0cDovL3d3dy5vbmxpbmV3ZWJmb250cy5jb20vaWNvbiA8L21ldGFkYXRhPg0KPGc+PGcgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMC4wMDAwMDAsNTExLjAwMDAwMCkgc2NhbGUoMC4xMDAwMDAsLTAuMTAwMDAwKSI+PHBhdGggZD0iTTM4ODguMSw0Nzc0Ljl2LTIzNS4xaDQxMS40aDQxNC4zbC04LjgtMzI5LjFsLTguOC0zMzJsLTExNy41LTguOGMtMjI5LjItMTQuNy02MjAtOTkuOS05MjUuNi0xOTYuOUMyMjU3LjQsMzIyMC42LDExNjcuMiwyMDY1LjgsODAyLjksNjQ5LjZjLTUxMS4zLTE5ODYuMywzODQuOS00MDAyLDIyMDYuNy00OTY1LjhjMzAyLjYtMTYxLjYsNzU4LjEtMzIwLjIsMTE1NC44LTQwNS41YzQyNi4xLTkxLjEsMTI1MS43LTkxLjEsMTY4MC43LDBjMTc2OC45LDM4MiwzMDQ0LjEsMTY1Ny4yLDM0MjYuMSwzNDI2LjFjOTEuMSw0MjYuMSw5MS4xLDEyNTQuNiwwLDE2NzcuOGMtNDIwLjIsMTk0Mi4yLTE5MzYuNCwzMzAyLjYtMzg5MC4zLDM0OTYuNmwtMTk5LjgsMjAuNnYzMjAuM3YzMjAuM2g0MTEuNGg0MTEuNHYyMzUuMVY1MDEwSDQ5NDUuOUgzODg4LjFWNDc3NC45eiBNNTc1My45LDMzNDkuOWM3NzguNy0xNjEuNiwxNDE5LjItNTA4LjMsMTk4My40LTEwNzIuNWM1NjQuMi01NjEuMiw4ODcuNC0xMTU3LjcsMTA2MC43LTE5NDIuMmM5OS45LTQzNy44LDk5LjktMTE0MywzLTE1ODAuOEM4NTYzLTIzMDYuNCw3OTY2LjUtMzE1OC41LDcwNDMuOS0zNzUyYy0zMzUtMjE0LjUtNzg3LjUtMzk2LjctMTI0OC44LTQ5OS41Yy00MzcuOC05Ny0xMTQzLTk3LTE1ODAuOCwyLjljLTc4NC41LDE3My4zLTEzODEsNDk2LjYtMTk0Mi4yLDEwNjAuN2MtNTcwLDU2Ny4xLTkwNy45LDExOTguOC0xMDc4LjQsMTk5OC4xYy03My41LDM0Ni43LTczLjUsMTEyMi40LDAsMTQ2OS4yYzE3MC40LDc5OS4yLDUwOC4zLDE0MzEsMTA3OC40LDE5OThDMjg5NSwyOTAwLjMsMzYzOC40LDMyNzMuNSw0NDkzLjQsMzM5MUM0Nzc4LjQsMzQzMi4xLDU0NzQuOCwzNDA4LjYsNTc1My45LDMzNDkuOXoiLz48cGF0aCBkPSJNNDcxMC44LDEzNzUuM1YyMDUuOUw0NTUyLjIsNjcuOGMtMzE3LjMtMjc5LjEtMzQwLjgtNjc4LjctNTUuOC05OTMuMWMyODcuOS0zMjAuMyw2OTMuNC0zMTcuMywxMDEzLjcsNS45bDE3MC40LDE3MC40aDEwNDMuMWgxMDQzLjFWLTUxNFYtMjc5SDY3MjkuNUg1NjkyLjJsLTQ5LjksMTE0LjZjLTU4LjgsMTMyLjItMjUyLjcsMzE3LjMtMzc2LjEsMzYxLjRsLTg1LjIsMjkuNHYxMTU3Ljd2MTE1Ny43aC0yMzUuMWgtMjM1LjFWMTM3NS4zeiBNNTE2Ni4zLTI5My42YzE0Ni45LTE0NCw0NC4xLTM5Ni43LTE2MS42LTM5Ni43Yy01NS44LDAtMTE3LjUsMjYuNC0xNjEuNiw3My40Yy00Nyw0NC4xLTczLjUsMTA1LjgtNzMuNSwxNjEuNnMyNi40LDExNy41LDczLjUsMTYxLjZjNDQuMSw0NywxMDUuOCw3My41LDE2MS42LDczLjVDNTA2MC41LTIyMC4yLDUxMjIuMi0yNDYuNyw1MTY2LjMtMjkzLjZ6Ii8+PC9nPjwvZz4NCjwvc3ZnPg=="
+    },
+    "labels": {
+      "camel.apache.org/kamelet.type": "source"
+    }
+  },
+  "spec": {
+    "definition": {
+      "title": "Timer Source",
+      "description": "Produces periodic events with a custom payload",
+      "required": [
+        "message"
+      ],
+      "properties": {
+        "period": {
+          "title": "Period",
+          "description": "The interval between two events",
+          "type": "integer",
+          "default": 1000
+        },
+        "message": {
+          "title": "Message",
+          "description": "The message to generate",
+          "type": "string",
+          "example": "hello world",
+          "x-descriptors": [
+            "urn:alm:descriptor:com.tectonic.ui:label"
+          ]
+        }
+      }
+    },
+    "types": {
+      "out": {
+        "mediaType": "text/plain"
+      }
+    },
+    "flow": {
+      "from": {
+        "uri": "timer:tick",
+        "parameters": {
+          "period": "#property:period"
+        },
+        "steps": [
+          {
+            "set-body": {
+              "constant": "{{message}}"
+            }
+          },
+          {
+            "to": "kamelet:sink"
+          }
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
When loading Kamelets support unrecognized fields such as x-descriptors set on properties in KameletSpec

Fixes #213