### PR TITLE
fix(#238): Port Selenium steps from Citrus to YAKS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -139,6 +139,7 @@ jobs:
         yaks test examples/settings
         yaks test examples/test-group
         yaks test examples/helloworld.feature
+        yaks test examples/selenium
 
   snapshot:
     runs-on: ubuntu-latest

--- a/examples/selenium/index.html
+++ b/examples/selenium/index.html
@@ -1,0 +1,36 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements. See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+-->
+
+<html lang="en">
+  <head>
+    <title>Test page</title>
+    <style type="text/css">
+      #hello-text:hover {
+        background-color: #009900;
+        color: #fff;
+      }
+    </style>
+  </head>
+  <body>
+    <h1 style="font-size: 40px;">Welcome!</h1>
+
+    <p><button id="open-alert" onclick="alert('Hello');">Say Hello!</button></p>
+    <p><a name="openAlert" onclick="alert('Hello');">Say Hello!</a></p>
+
+    <span id="hello-text"><b>Hello!</b></span>
+  </body>
+</html>

--- a/examples/selenium/selenium.feature
+++ b/examples/selenium/selenium.feature
@@ -1,0 +1,19 @@
+Feature: Selenium feature
+
+  Background:
+    Given load endpoint web-server.groovy
+    Given HTTP request timeout is 60000 ms
+    Given wait for GET on URL http://localhost:4444/wd/hub/status
+    Given start browser
+
+  Scenario: Index page
+    Given user navigates to "http://localhost:8080/"
+    And browser page should display heading with tag-name="h1" having
+    | text   | Welcome!       |
+    | styles | font-size=40px |
+    And browser page should display element with id="hello-text" having
+    | text   | Hello!         |
+    | styles | background-color=rgba(0, 0, 0, 0) |
+    When user clicks element with id="open-alert"
+    And sleep 500 ms
+    Then browser page should display alert with text "Hello"

--- a/examples/selenium/web-server.groovy
+++ b/examples/selenium/web-server.groovy
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+import com.consol.citrus.endpoint.EndpointAdapter
+import com.consol.citrus.endpoint.adapter.RequestDispatchingEndpointAdapter
+import com.consol.citrus.endpoint.adapter.StaticEndpointAdapter
+import com.consol.citrus.endpoint.adapter.mapping.HeaderMappingKeyExtractor
+import com.consol.citrus.endpoint.adapter.mapping.SimpleMappingStrategy
+import com.consol.citrus.http.message.HttpMessage
+import com.consol.citrus.http.message.HttpMessageHeaders
+import com.consol.citrus.message.Message
+import com.consol.citrus.util.FileUtils
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.core.io.ClassPathResource
+
+EndpointAdapter templateResponseAdapter() {
+    RequestDispatchingEndpointAdapter dispatchingEndpointAdapter = new RequestDispatchingEndpointAdapter()
+
+    Map<String, EndpointAdapter> mappings = new HashMap<>()
+
+    mappings.put("/", indexPageHandler())
+    mappings.put("/favicon.ico", faviconHandler())
+
+    SimpleMappingStrategy mappingStrategy = new SimpleMappingStrategy()
+    mappingStrategy.setAdapterMappings(mappings)
+    dispatchingEndpointAdapter.setMappingStrategy(mappingStrategy)
+
+    dispatchingEndpointAdapter.setMappingKeyExtractor(new HeaderMappingKeyExtractor(HttpMessageHeaders.HTTP_REQUEST_URI))
+
+    return dispatchingEndpointAdapter
+}
+
+static EndpointAdapter indexPageHandler() {
+    return new StaticEndpointAdapter() {
+        @Override
+        protected Message handleMessageInternal(Message message) {
+            try {
+                return new HttpMessage(FileUtils.readToString(new ClassPathResource("index.html")))
+                        .contentType(MediaType.TEXT_HTML_VALUE)
+                        .status(HttpStatus.OK)
+            } catch (IOException ignored) {
+                return new HttpMessage().status(HttpStatus.INTERNAL_SERVER_ERROR)
+            }
+        }
+    }
+}
+
+static EndpointAdapter faviconHandler() {
+    return new StaticEndpointAdapter() {
+        @Override
+        protected Message handleMessageInternal(Message message) {
+            return new HttpMessage().status(HttpStatus.OK)
+        }
+    }
+}
+
+http()
+    .server()
+    .port(8080)
+    .endpointAdapter(templateResponseAdapter())
+    .autoStart(true)

--- a/examples/selenium/yaks-config.yaml
+++ b/examples/selenium/yaks-config.yaml
@@ -1,0 +1,27 @@
+# ---------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ---------------------------------------------------------------------------
+
+config:
+  runtime:
+    selenium:
+      image: selenium/standalone-chrome:88.0
+    env:
+      - name: YAKS_SELENIUM_BROWSER_TYPE
+        value: chrome
+    resources:
+      - index.html
+      - web-server.groovy

--- a/java/docs/steps-selenium.adoc
+++ b/java/docs/steps-selenium.adoc
@@ -1,0 +1,551 @@
+[[steps-selenium]]
+== Selenium steps
+
+Selenium is a very popular UI testing tool that enables you to simulate user interactions on a web frontend. Selenium
+supports a wide range of browsers and is able to run with a grid of nodes in a Kubernetes environment.
+
+YAKS provides ready-to-use steps that leverage Selenium UI testing with Cloud-native BDD. Have a look at the complete
+example in xref:../../examples/selenium/selenium.feature[examples/selenium.feature].
+
+The following sections guide you through the Selenium capabilities in YAKS.
+
+[[selenium-browser-type]]
+=== Browser type
+
+Selenium supports many browsers. When running a YAKS test with Selenium you need to choose which browser type to use. By
+default, YAKS uses the `htmlunit` browser type. You can overwrite this type with the system property `yaks.selenium.browser.type`
+or environment variable `YAKS_SELENIUM_BROWSER_TYPE` set on the YAKS configuration.
+
+.Set Selenium browser type
+[source,bash]
+----
+YAKS_SELENIUM_BROWSER_TYPE=chrome
+----
+
+These are the supported browser types:
+
+* firefox
+* safari
+* MicrosoftEdge
+* safariproxy
+* chrome
+* htmlunit
+* internet explorer
+* phantomjs
+
+This sets the Selenium browser type for all operations.
+
+[[selenium-browser]]
+=== Selenium broker
+
+YAKS creates a default browser component using the given link:#selenium-browser-type[browser type]. You can also create a
+browser instance by yourself and reference this in your test by its name.
+
+.@Given("^(?:Browser|browser) "{name}"$")
+[source,gherkin]
+----
+Given browser "{name}"
+----
+
+This loads the browser component with given name from the configuration (e.g. Spring application context).
+
+You can also use the system property `yaks.selenium.browser.name` environment variable `YAKS_SELENIUM_BROWSER_NAME`
+
+[[selenium-browser-remote]]
+=== Remote web driver
+
+As soon as the YAKS test is run on a Kubernetes environment you must use a remote web driver. This is because the default YAKS test
+runtime pod is not able to run UI tests because no web browser infrastructure is installed in the image.
+
+You can automatically start a Selenium sidecar container as part of the test runtime pod. The https://hub.docker.com/u/selenium[Selenium images]
+provide the required web browser infrastructure for UI testing. YAKS adds the Selenium container as a sidecar to the test
+runtime. Now your test is able to connect with the remote browser using a remote web driver connection.
+
+Add the following configuration to the `yaks-config.yaml` in your test.
+
+.yaks-config.yaml
+[source,yaml]
+----
+config:
+  runtime:
+    selenium:
+      image: selenium/standalone-chrome:88.0
+    env:
+      - name: YAKS_SELENIUM_BROWSER_TYPE
+        value: chrome
+      - name: YAKS_SELENIUM_BROWSER_REMOTE_SERVER_URL
+        value: http://localhost:4444/wd/hub
+----
+
+This sets the Selenium container image (`selenium/standalone-chrome:88.0`), the browser type and the remote web driver URL.
+YAKS automatically starts the given Selenium container image and connects the browser to the remote web driver.
+
+This way you can run the UI tests in a Kubernetes environment.
+
+[[selenium-start-stop]]
+=== Start/stop browser
+
+Before you can run some user interactions with Selenium you need to start the browser.
+
+.@Given("^start browser$")
+[source,gherkin]
+----
+Given start browser
+----
+
+.@Given("^stop browser$")
+[source,gherkin]
+----
+Given stop browser
+----
+
+[[selenium-navigate]]
+=== Navigate to URL
+
+See the following step that navigates to a given URL in the browser.
+
+.@When("^(?:User|user) navigates to "{url}"$")
+[source,gherkin]
+----
+When User navigates to "{url}"
+----
+
+[[selenium-verify-elements]]
+=== Verify elements on page
+
+Selenium is able to verify web elements on the current page. You can select the element by its attributes (e.g. id, name, style)
+and verify its properties (e.g. text value, styles).
+
+.@When("^(?:Browser|browser) page should display {element-type} with {attribute}="{value}"$")
+[source,gherkin]
+----
+When Browser page should display {element-type} with {attribute}="{value}"
+----
+
+This step verifies that the given element of type `{element-type}` is present on the current web page. The element is selected
+by the given `{attribute}` and `{value}`.
+
+.Verify heading with text
+[source,gherkin]
+----
+When Browser page should display heading with text="Welcome!"
+----
+
+Possible element types are:
+
+* element
+* button
+* link
+* input
+* textfield
+* form
+* heading
+
+Possible attributes to select the element are:
+
+* id
+* name
+* class-name
+* link-text
+* css-selector
+* tag-name
+* xpath
+
+You can add additional attribute validations in a data table
+
+.Verify element with attributes
+[source,gherkin]
+----
+When And browser page should display element with id="hello-text" having
+    | text   | Hello!         |
+    | styles | background-color=rgba(0, 0, 0, 0) |
+----
+
+[[selenium-click]]
+=== Click elements
+
+You can click on elements such as buttons or links. The element must be identified by an attribute (e.g. id, name, style)
+with a given value.
+
+.@When("^(?:User|user) clicks (?:element|button|link) with {attribute}="{value}"$")
+[source,gherkin]
+----
+When User clicks (element|button|link) with {attribute}="{value}"
+----
+
+.Click button by id
+[source,gherkin]
+----
+When User clicks button with id="submit"
+----
+
+[[selenium-forms]]
+=== Form controls
+
+Filling out a user form on a web page is a very common use case in UI testing. YAKS is able to enter text into input fields,
+select items from a drop down list and check/uncheck checkboxes.
+
+==== Input fields
+
+.@When("^(?:User|user) enters text "{input}" to (?:element|input|textfield) with {attribute}="{value}"$")
+[source,gherkin]
+----
+When User enters text "{input}" to (element|input|textfield) with {attribute}="{value}"
+----
+
+.Enter text in input field
+[source,gherkin]
+----
+When User enters text "Christoph" to input with id="name"
+----
+
+==== Checkboxes
+
+.@When("^(?:User|user) (checks|unchecks) checkbox with {attribute}="{value}"$")
+[source,gherkin]
+----
+When User (checks|unchecks) checkbox with {attribute}="{value}"
+----
+
+.Check checkbox
+[source,gherkin]
+----
+When User checks checkbox with id="show-details"
+----
+
+==== Dropdowns
+
+.@When("^(?:User|user) selects option "{option}" on (?:element|dropdown) with {attribute}="{value}"$")
+[source,gherkin]
+----
+When User selects option "{option}" with {attribute}="{value}"
+----
+
+.Check checkbox
+[source,gherkin]
+----
+When User selects option "21-30" on dropdown with id="age"
+----
+
+[[selenium-alert]]
+=== Alert dialogs
+
+Web pages can open alert dialogs that need to be accepted or dismissed.
+
+.@When("^(?:User|user) (accepts|dismisses) alert$")
+[source,gherkin]
+----
+When User (accepts|dismisses) alert
+----
+
+You can also verify the alert text displayed to the user.
+
+.@When("^(?:Browser|browser) page should display alert with text "{text}"$")
+[source,gherkin]
+----
+When Browser page should display alert with text "{text}"
+----
+
+.Verify alert with text
+[source,gherkin]
+----
+When Browser page should display alert with text "WARNING!"
+----
+
+IMPORTANT: The alert text verification implicitly accepts the alert dialog after validation.
+
+[[selenium-pages]]
+=== Page objects
+
+Selenium provides a good way to encapsulate web page capabilities in form of page objects. These object usually defines elements
+on a web page and perform predefined operations on that page.
+
+.Page object
+[source,java]
+----
+public class UserFormPage implements WebPage {
+
+    @FindBy(id = "userForm")
+    private WebElement form;
+
+    @FindBy(id = "username")
+    private WebElement userName;
+
+    /**
+     * Sets the user name.
+     * @param value
+     */
+    public void setUserName(String value) {
+        userName.clear();
+        userName.sendKeys(value);
+    }
+
+    /**
+     * Submits the form.
+     */
+    public void submit() {
+        form.submit();
+    }
+}
+----
+
+The page object above defines a `form` element as well as a `username` input text field. The page identifies the elements
+with `@FindBy` annotations. In addition, the page defines operations such as `setUserName` and `submit`.
+
+YAKS is able to load the page objects by its name in the current configuration (e.g. Spring application context).
+
+.@Given("^(?:Browser|browser) page "{name}"$")
+[source,gherkin]
+----
+Given Browser page "{name}"
+----
+
+The step loads the page object that has been added to the configuration with the given name.
+
+You can also instantiate new page objects by its types as follows:
+
+.@Given("^(?:Browser|browser) page "{name}" of type {type}$")
+[source,gherkin]
+----
+Given Browser page "{name}" of type {type}
+----
+
+.Instantiate UserForm page
+[source,gherkin]
+----
+Given Browser page "userForm" of type org.sample.UserFormPage
+----
+
+This loads a new page object of type `org.sample.UserFormPage`. Please make sure that the given class is available on the test
+classpath and that the class provides a default constructor.
+
+You can instantiate many web page objects in a single step.
+
+.Instantiate many page objects
+[source,gherkin]
+----
+Given Browser page types
+  | indexPage | org.sample.IndexPage     |
+  | userForm  | org.sample.UserFormPage  |
+  | orderForm | org.sample.OrderFormPage |
+----
+
+Once the page objects are loaded you can perform operations.
+
+.@Given("^(?:Browser|browser) page {name} performs {operation}$")
+[source,gherkin]
+----
+Given Browser page {name} performs {operation}
+----
+
+.Call submit operation on userForm
+[source,gherkin]
+----
+Given Browser page userForm performs submit
+----
+
+The step uses the given page object `userForm` and performs the `submit` operation. This simply calls the `submit()` method
+on the page object.
+
+.Page object
+[source,java]
+----
+public class UserFormPage implements WebPage {
+
+    @FindBy(id = "userForm")
+    private WebElement form;
+
+    /**
+     * Submits the form.
+     */
+    public void submit() {
+        form.submit();
+    }
+}
+----
+
+In case the operation requires parameters you can set those on the operation call.
+
+.Call setUserName operation with arguments
+[source,gherkin]
+----
+Given Browser page userForm performs setUserName with arguments
+  | Christoph |
+----
+
+The `setUserName` operation on the page object requires the username value as a parameter. This value is set as `Christoph` in
+the step above.
+
+.Page object
+[source,java]
+----
+public class UserFormPage implements WebPage {
+
+    @FindBy(id = "username")
+    private WebElement userName;
+
+    /**
+     * Sets the user name.
+     * @param value
+     */
+    public void setUserName(String value) {
+        userName.clear();
+        userName.sendKeys(value);
+    }
+}
+----
+
+Each page operation can use the current `TestContext` as argument, too. This context will be automatically injected by YAKS
+when the operation is called.
+
+.Use test context in page objects
+[source,java]
+----
+public class UserFormPage implements WebPage {
+
+    @FindBy(id = "username")
+    private WebElement userName;
+
+    /**
+     * Sets the user name.
+     * @param value
+     * @param context
+     */
+    public void setUserName(String value, TestContext context) {
+        userName.clear();
+        userName.sendKeys(value);
+
+        context.setVariable("username", value);
+    }
+}
+----
+
+The page operation `setUserName` uses the `TestContext` as additional method argument and is able to set a new test variable.
+All subsequent steps in the test are able to access this new variable with `${username}` then.
+
+[[selenium-page-validators]]
+=== Page validator
+
+The previous section has introduced the concept of page objects and how to perform operations on the given page. You can also
+use page objects to verify the page contents.
+
+.Page validator
+[source,java]
+----
+public class UserFormPageValidator implements PageValidator<UserFormPage> {
+
+    @Override
+    public void validate(UserFormPage webPage, SeleniumBrowser browser, TestContext context) {
+        Assert.assertNotNull(webPage.userName);
+        Assert.assertTrue(StringUtils.hasText(webPage.userName.getAttribute("value")));
+        Assert.assertNotNull(webPage.form);
+    }
+}
+----
+
+The page validator implements the `PageValidator<>` interface and implements a `validate` method. The validation is provided
+with the actual page object, the browser instance and the current test context.
+
+The validator should verify that the current state on the page is as expected.
+
+YAKS is able to load the page validator by its name in the current configuration (e.g. Spring application context).
+
+.@Given("^(?:Browser|browser) page validator "{name}"$")
+[source,gherkin]
+----
+Given Browser page validator "{name}"
+----
+
+The step loads the page validator that has been added to the configuration with the given name.
+
+You can also instantiate new page validator objects by its types as follows:
+
+.@Given("^(?:Browser|browser) page validator "{name}" of type {type}$")
+[source,gherkin]
+----
+Given Browser page validator "{name}" of type {type}
+----
+
+.Create page validator
+[source,gherkin]
+----
+Given Browser page validator "userFormValidator" of type org.sample.UserFormPageValidator
+----
+
+This loads a new page validator of type `org.sample.UserFormPageValidator`. Please make sure that the given class is available on the test
+classpath and that the class provides a default constructor.
+
+You can instantiate many web page validator objects in a single step.
+
+.Instantiate many page validator objects
+[source,gherkin]
+----
+Given Browser page validator types
+  | indexPageValidator | org.sample.IndexPageValidator     |
+  | userFormValidator  | org.sample.UserFormPageValidator  |
+  | orderFormValidator | org.sample.OrderFormPageValidator |
+----
+
+Once the page validator objects are loaded you can perform its validations.
+
+.@Given("^(?:Browser|browser) page {name} should validate with {validator}$")
+[source,gherkin]
+----
+Given Browser page {name} should validate with {validator}
+----
+
+.Validate userForm page with userFormValidator
+[source,gherkin]
+----
+Given Browser page userForm should validate with userFormValidator
+----
+
+The step calls the `validate` method on the page validator `userFormValidator` and passes the `userForm` page object as
+argument.
+
+.Page validator
+[source,java]
+----
+public class UserFormPageValidator implements PageValidator<UserFormPage> {
+
+    @Override
+    public void validate(UserFormPage webPage, SeleniumBrowser browser, TestContext context) {
+        Assert.assertNotNull(webPage.userName);
+        Assert.assertTrue(StringUtils.hasText(webPage.userName.getAttribute("value")));
+        Assert.assertNotNull(webPage.form);
+    }
+}
+----
+
+The validator accesses the elements and operations provided in the page object and makes sure the state is as expected.
+
+TIP: The page object itself can also implement the page validator interface. This way you can combine the concept of
+page objects and validator in a single class. The step to verify the page is then able to just use the page object name.
+
+.Validate userForm page with implicit validator
+[source,gherkin]
+----
+Given Browser page userForm should validate
+----
+
+.Page object implementing validator
+[source,java]
+----
+public class UserFormPage implements WebPage, PageValidator<UserFormPage> {
+
+    @FindBy(id = "userForm")
+    private WebElement form;
+
+    @FindBy(id = "username")
+    private WebElement userName;
+
+    [...]
+
+    @Override
+    public void validate(UserFormPage webPage, SeleniumBrowser browser, TestContext context) {
+        Assert.assertNotNull(userName);
+        Assert.assertTrue(StringUtils.hasText(userName.getAttribute("value")));
+        Assert.assertNotNull(form);
+    }
+}
+----

--- a/java/docs/steps.adoc
+++ b/java/docs/steps.adoc
@@ -18,5 +18,4 @@ include::steps-kafka.adoc[]
 include::steps-kubernetes.adoc[]
 include::steps-knative.adoc[]
 include::steps-openapi.adoc[]
-
-
+include::steps-selenium.adoc[]

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -191,6 +191,11 @@
         <artifactId>citrus-ws</artifactId>
         <version>${citrus.version}</version>
       </dependency>
+      <dependency>
+        <groupId>com.consol.citrus</groupId>
+        <artifactId>citrus-selenium</artifactId>
+        <version>${citrus.version}</version>
+      </dependency>
 
       <!-- Cucumber -->
       <dependency>

--- a/java/runtime/yaks-runtime-maven/pom.xml
+++ b/java/runtime/yaks-runtime-maven/pom.xml
@@ -88,6 +88,11 @@
     </dependency>
     <dependency>
       <groupId>org.citrusframework.yaks</groupId>
+      <artifactId>yaks-selenium</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.citrusframework.yaks</groupId>
       <artifactId>yaks-standard</artifactId>
       <version>${project.version}</version>
     </dependency>
@@ -123,7 +128,69 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-failsafe-plugin</artifactId>
+          <version>${surefire.version}</version>
+          <executions>
+            <execution>
+              <id>integration-tests</id>
+              <goals>
+                <goal>integration-test</goal>
+                <goal>verify</goal>
+              </goals>
+              <configuration>
+                <failIfNoTests>false</failIfNoTests>
+              </configuration>
+            </execution>
+          </executions>
+        </plugin>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>exec-maven-plugin</artifactId>
+          <version>3.0.0</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+
   <profiles>
+    <profile>
+      <id>selenium</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>exec-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>shutdown-selenium-process</id>
+                <phase>post-integration-test</phase>
+                <goals>
+                  <goal>exec</goal>
+                </goals>
+                <configuration>
+                  <executable>pkill</executable>
+                  <arguments>
+                    <argument>-f</argument>
+                    <argument>supervisord</argument>
+                  </arguments>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
     <profile>
       <id>local-settings</id>
       <properties>

--- a/java/runtime/yaks-runtime-maven/src/test/java/org/citrusframework/yaks/Yaks_IT.java
+++ b/java/runtime/yaks-runtime-maven/src/test/java/org/citrusframework/yaks/Yaks_IT.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.yaks;
+
+import io.cucumber.junit.Cucumber;
+import io.cucumber.junit.CucumberOptions;
+import org.junit.runner.RunWith;
+
+@RunWith(Cucumber.class)
+@CucumberOptions(
+        plugin = { "pretty", "org.citrusframework.yaks.report.TestReporter" }
+)
+public class Yaks_IT {
+}

--- a/java/steps/pom.xml
+++ b/java/steps/pom.xml
@@ -40,5 +40,6 @@
     <module>yaks-standard</module>
     <module>yaks-openapi</module>
     <module>yaks-groovy</module>
+    <module>yaks-selenium</module>
   </modules>
 </project>

--- a/java/steps/yaks-http/src/main/java/org/citrusframework/yaks/http/HttpClientSteps.java
+++ b/java/steps/yaks-http/src/main/java/org/citrusframework/yaks/http/HttpClientSteps.java
@@ -30,7 +30,6 @@ import com.consol.citrus.CitrusSettings;
 import com.consol.citrus.TestCaseRunner;
 import com.consol.citrus.annotations.CitrusFramework;
 import com.consol.citrus.annotations.CitrusResource;
-import com.consol.citrus.container.Wait;
 import com.consol.citrus.exceptions.CitrusRuntimeException;
 import com.consol.citrus.http.actions.HttpClientActionBuilder;
 import com.consol.citrus.http.actions.HttpClientRequestActionBuilder;
@@ -56,6 +55,7 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.util.StringUtils;
 
+import static com.consol.citrus.container.Wait.Builder.waitFor;
 import static com.consol.citrus.http.actions.HttpActionBuilder.http;
 import static com.consol.citrus.validation.PathExpressionValidationContext.Builder.pathExpression;
 
@@ -169,7 +169,7 @@ public class HttpClientSteps implements HttpSteps {
 
     @Given("^wait for (?:URL|url|path) ([^\\s]+) to return (\\d+)(?: [^\\s]+)?$")
     public void waitForHttpStatus(String urlOrPath, Integer statusCode) {
-        runner.given(Wait.Builder.waitFor().http()
+        runner.given(waitFor().http()
                 .milliseconds(timeout)
                 .interval(timeout / 10)
                 .status(statusCode)
@@ -178,7 +178,7 @@ public class HttpClientSteps implements HttpSteps {
 
     @Given("^wait for (GET|HEAD|POST|PUT|PATCH|DELETE|OPTIONS|TRACE) on (?:URL|url|path) ([^\\s]+) to return (\\d+)(?: [^\\s]+)?$")
     public void waitForHttpStatusUsingMethod(String method, String urlOrPath, Integer statusCode) {
-        runner.given(Wait.Builder.waitFor().http()
+        runner.given(waitFor().http()
                 .milliseconds(timeout)
                 .method(method)
                 .interval(timeout / 10)

--- a/java/steps/yaks-http/src/main/java/org/citrusframework/yaks/http/HttpSettings.java
+++ b/java/steps/yaks-http/src/main/java/org/citrusframework/yaks/http/HttpSettings.java
@@ -22,7 +22,7 @@ package org.citrusframework.yaks.http;
  */
 public class HttpSettings {
 
-    private static final String HTTP_PROPERTY_PREFIX = "yaks.kubernetes.";
+    private static final String HTTP_PROPERTY_PREFIX = "yaks.http.";
     private static final String HTTP_ENV_PREFIX = "YAKS_HTTP_";
 
     private static final String TIMEOUT_PROPERTY = HTTP_PROPERTY_PREFIX + ".timeout";

--- a/java/steps/yaks-knative/src/main/java/org/citrusframework/yaks/knative/KnativeSettings.java
+++ b/java/steps/yaks-knative/src/main/java/org/citrusframework/yaks/knative/KnativeSettings.java
@@ -67,7 +67,6 @@ public class KnativeSettings {
 
     private static final String SERVICE_PORT_PROPERTY = KNATIVE_PROPERTY_PREFIX + "service.port";
     private static final String SERVICE_PORT_ENV = KNATIVE_ENV_PREFIX + "SERVICE_PORT";
-    private static final String SERVICE_PORT_DEFAULT = "8080";
 
     private static final String AUTO_REMOVE_RESOURCES_PROPERTY = KNATIVE_PROPERTY_PREFIX + "auto.remove.resources";
     private static final String AUTO_REMOVE_RESOURCES_ENV = KNATIVE_ENV_PREFIX + "AUTO_REMOVE_RESOURCES";

--- a/java/steps/yaks-selenium/pom.xml
+++ b/java/steps/yaks-selenium/pom.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements. See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <groupId>org.citrusframework.yaks</groupId>
+    <artifactId>yaks-steps</artifactId>
+    <version>0.3.0-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>yaks-selenium</artifactId>
+  <name>YAKS :: Steps :: Selenium</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.cucumber</groupId>
+      <artifactId>cucumber-java</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.consol.citrus</groupId>
+      <artifactId>citrus-base</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.consol.citrus</groupId>
+      <artifactId>citrus-selenium</artifactId>
+    </dependency>
+
+    <!-- Test scope -->
+    <dependency>
+      <groupId>io.cucumber</groupId>
+      <artifactId>cucumber-junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.consol.citrus</groupId>
+      <artifactId>citrus-cucumber</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.consol.citrus</groupId>
+      <artifactId>citrus-spring</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.citrusframework.yaks</groupId>
+      <artifactId>yaks-standard</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.citrusframework.yaks</groupId>
+      <artifactId>yaks-http</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/java/steps/yaks-selenium/src/main/java/org/citrusframework/yaks/selenium/SeleniumSettings.java
+++ b/java/steps/yaks-selenium/src/main/java/org/citrusframework/yaks/selenium/SeleniumSettings.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.yaks.selenium;
+
+import org.openqa.selenium.remote.BrowserType;
+
+/**
+ * @author Christoph Deppisch
+ */
+public class SeleniumSettings {
+
+    private static final String SELENIUM_PROPERTY_PREFIX = "yaks.selenium.";
+    private static final String SELENIUM_ENV_PREFIX = "YAKS_SELENIUM_";
+
+    private static final String BROWSER_NAME_PROPERTY = SELENIUM_PROPERTY_PREFIX + "browser.name";
+    private static final String BROWSER_NAME_ENV = SELENIUM_ENV_PREFIX + "BROWSER_NAME";
+    private static final String BROWSER_NAME_DEFAULT = "seleniumBrowser";
+
+    private static final String BROWSER_TYPE_PROPERTY = SELENIUM_PROPERTY_PREFIX + "browser.type";
+    private static final String BROWSER_TYPE_ENV = SELENIUM_ENV_PREFIX + "BROWSER_TYPE";
+    private static final String BROWSER_TYPE_DEFAULT = BrowserType.HTMLUNIT;
+
+    private static final String BROWSER_REMOTE_SERVER_URL_PROPERTY = SELENIUM_PROPERTY_PREFIX + "browser.remote.server.url";
+    private static final String BROWSER_REMOTE_SERVER_URL_ENV = SELENIUM_ENV_PREFIX + "BROWSER_REMOTE_SERVER_URL";
+    private static final String BROWSER_REMOTE_SERVER_URL_DEFAULT = "http://localhost:4444/wd/hub";
+
+    private SeleniumSettings() {
+        // prevent instantiation of utility class
+    }
+
+    /**
+     * Browser name used by default to load component from context on startup.
+     * @return
+     */
+    public static String getBrowserName() {
+        return System.getProperty(BROWSER_NAME_PROPERTY,
+                System.getenv(BROWSER_NAME_ENV) != null ? System.getenv(BROWSER_NAME_ENV) : BROWSER_NAME_DEFAULT);
+    }
+
+    /**
+     * Browser type used by default when creating new browser instances.
+     * @return
+     */
+    public static String getBrowserType() {
+        return System.getProperty(BROWSER_TYPE_PROPERTY,
+                System.getenv(BROWSER_TYPE_ENV) != null ? System.getenv(BROWSER_TYPE_ENV) : BROWSER_TYPE_DEFAULT);
+    }
+
+    /**
+     * Browser remote server url. Optional setting to use a remote web driver pointing to the given url.
+     * @return
+     */
+    public static String getBrowserRemoteServerUrl() {
+        return System.getProperty(BROWSER_REMOTE_SERVER_URL_PROPERTY,
+                System.getenv(BROWSER_REMOTE_SERVER_URL_ENV) != null ? System.getenv(BROWSER_REMOTE_SERVER_URL_ENV) : BROWSER_REMOTE_SERVER_URL_DEFAULT);
+    }
+
+}

--- a/java/steps/yaks-selenium/src/main/java/org/citrusframework/yaks/selenium/SeleniumSteps.java
+++ b/java/steps/yaks-selenium/src/main/java/org/citrusframework/yaks/selenium/SeleniumSteps.java
@@ -1,0 +1,327 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.yaks.selenium;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.consol.citrus.Citrus;
+import com.consol.citrus.TestCaseRunner;
+import com.consol.citrus.annotations.CitrusFramework;
+import com.consol.citrus.annotations.CitrusResource;
+import com.consol.citrus.exceptions.CitrusRuntimeException;
+import com.consol.citrus.selenium.actions.FindElementAction;
+import com.consol.citrus.selenium.endpoint.SeleniumBrowser;
+import com.consol.citrus.selenium.endpoint.SeleniumBrowserBuilder;
+import com.consol.citrus.selenium.model.PageValidator;
+import com.consol.citrus.selenium.model.WebPage;
+import com.consol.citrus.variable.VariableUtils;
+import io.cucumber.datatable.DataTable;
+import io.cucumber.java.Before;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
+import org.springframework.util.StringUtils;
+
+import static com.consol.citrus.selenium.actions.SeleniumActionBuilder.selenium;
+
+/**
+ * @author Christoph Deppisch
+ */
+public class SeleniumSteps {
+
+    @CitrusResource
+    protected TestCaseRunner runner;
+
+    @CitrusFramework
+    protected Citrus citrus;
+
+    /** Page objects defined by id */
+    private Map<String, WebPage> pages;
+
+    /** Page validators defined by id */
+    private Map<String, PageValidator<?>> validators;
+
+    private final String browserType = SeleniumSettings.getBrowserType();
+    private final String browserName = SeleniumSettings.getBrowserName();
+    private final String browserRemoteServerUrl = SeleniumSettings.getBrowserRemoteServerUrl();
+
+    /** Selenium browser */
+    protected SeleniumBrowser browser;
+
+    @Before
+    public void before() {
+        if (browser == null && citrus.getCitrusContext().getReferenceResolver().resolveAll(SeleniumBrowser.class).size() == 1L) {
+            browser = citrus.getCitrusContext().getReferenceResolver().resolve(SeleniumBrowser.class);
+        } else if (citrus.getCitrusContext().getReferenceResolver().isResolvable(browserName)) {
+            browser = citrus.getCitrusContext().getReferenceResolver().resolve(browserName, SeleniumBrowser.class);
+        } else {
+            browser = new SeleniumBrowserBuilder()
+                    .type(browserType)
+                    .remoteServer(browserRemoteServerUrl)
+                    .build();
+            citrus.getCitrusContext().bind(browserName, browser);
+        }
+
+        pages = new HashMap<>();
+        validators = new HashMap<>();
+    }
+
+    @Given("^(?:Browser|browser) \"([^\"]+)\"$")
+    public void setBrowser(String id) {
+        if (!citrus.getCitrusContext().getReferenceResolver().isResolvable(id)) {
+            throw new CitrusRuntimeException("Unable to find selenium browser for id: " + id);
+        }
+
+        browser = citrus.getCitrusContext().getReferenceResolver().resolve(id, SeleniumBrowser.class);
+    }
+
+    @When("^start browser$")
+    public void start() {
+        runner.run(selenium().browser(browser)
+                .start());
+    }
+
+    @When("^stop browser$")
+    public void stop() {
+        runner.run(selenium().browser(browser)
+                .stop());
+    }
+
+    @When("^(?:User|user) navigates to \"([^\"]+)\"$")
+    public void navigate(String url) {
+        runner.run(selenium().browser(browser)
+                .navigate(url));
+    }
+
+    @When("^(?:User|user) clicks (?:element|button|link) with ([^\"]+)=\"([^\"]+)\"$")
+    public void click(String property, String value) {
+        runner.run(selenium().browser(browser)
+                .click()
+                .element(property, value));
+    }
+
+    @When("^(?:User|user) enters text \"([^\"]+)\" to (?:element|input|textfield) with ([^\"]+)=\"([^\"]+)\"$")
+    public void setInput(String text, String property, String value) {
+        runner.run(selenium().browser(browser)
+                .setInput(text)
+                .element(property, value));
+    }
+
+    @When("^(?:User|user) (checks|unchecks) checkbox with ([^\"]+)=\"([^\"]+)\"$")
+    public void checkInput(String type, String property, String value) {
+        runner.run(selenium().browser(browser)
+                .checkInput(type.equals("checks"))
+                .element(property, value));
+    }
+
+    @When("^(?:User|user) selects option \"([^\"]+)\" on (?:element|dropdown) with ([^\"]+)=\"([^\"]+)\"$")
+    public void select(String option, String property, String value) {
+        runner.run(selenium().browser(browser)
+                .select(option)
+                .element(property, value));
+    }
+
+    @When("^(?:User|user) (accepts|dismisses) alert$")
+    public void acceptAlert(String type) {
+        if (type.equals("accepts")) {
+            runner.run(selenium().browser(browser)
+                    .alert()
+                    .accept());
+        } else {
+            runner.run(selenium().browser(browser)
+                    .alert()
+                    .dismiss());
+        }
+    }
+
+    @When("^(?:Browser|browser) page should display alert with text \"([^\"]+)\"$")
+    public void shouldDisplayAlert(String text) {
+        runner.run(selenium().browser(browser)
+                .alert()
+                .text(text));
+    }
+
+    @Then("^(?:Browser|browser) page should display (?:element|button|link|input|textfield|form|heading) with (id|name|class-name|link-text|css-selector|tag-name|xpath)=\"([^\"]+)\"$")
+    public void shouldDisplay(String property, String value) {
+        runner.run(selenium().browser(browser)
+                .find()
+                .enabled(true)
+                .displayed(true)
+                .element(property, value));
+    }
+
+    @Then("^(?:Browser|browser) page should display (?:element|button|link|input|textfield|form|heading) with (id|name|class-name|link-text|css-selector|tag-name|xpath)=\"([^\"]+)\" having$")
+    public void shouldDisplay(String property, String value, DataTable dataTable) {
+        Map<String, String> elementProperties = dataTable.asMap(String.class, String.class);
+
+        FindElementAction.Builder elementBuilder = selenium().browser(browser)
+                .find()
+                .element(property, value);
+
+        for (Map.Entry<String, String> propertyEntry : elementProperties.entrySet()) {
+            if (propertyEntry.getKey().equals("tag-name")) {
+                elementBuilder.tagName(propertyEntry.getValue());
+            }
+
+            if (propertyEntry.getKey().equals("text")) {
+                elementBuilder.text(propertyEntry.getValue());
+            }
+
+            if (propertyEntry.getKey().equals("enabled")) {
+                elementBuilder.enabled(Boolean.parseBoolean(propertyEntry.getValue()));
+            }
+
+            if (propertyEntry.getKey().equals("displayed")) {
+                elementBuilder.displayed(Boolean.parseBoolean(propertyEntry.getValue()));
+            }
+
+            if (propertyEntry.getKey().equals("styles") || propertyEntry.getKey().equals("style")) {
+                String[] propertyExpressions = StringUtils.delimitedListToStringArray(propertyEntry.getValue(), ";");
+                for (String propertyExpression : propertyExpressions) {
+                    String[] keyValue = propertyExpression.split("=");
+                    elementBuilder.style(keyValue[0].trim(), VariableUtils.cutOffDoubleQuotes(keyValue[1].trim()));
+                }
+            }
+
+            if (propertyEntry.getKey().equals("attributes") || propertyEntry.getKey().equals("attribute")) {
+                String[] propertyExpressions = StringUtils.commaDelimitedListToStringArray(propertyEntry.getValue());
+                for (String propertyExpression : propertyExpressions) {
+                    String[] keyValue = propertyExpression.split("=");
+                    elementBuilder.attribute(keyValue[0].trim(), VariableUtils.cutOffDoubleQuotes(keyValue[1].trim()));
+                }
+            }
+        }
+
+        runner.run(elementBuilder);
+    }
+
+    @Given("^(?:Browser|browser) page types$")
+    public void pages(DataTable dataTable) {
+        Map<String, String> variables = dataTable.asMap(String.class, String.class);
+        for (Map.Entry<String, String> entry : variables.entrySet()) {
+            pageByType(entry.getKey(), entry.getValue());
+        }
+    }
+
+    @Given("^(?:Browser|browser) page \"([^\"]+)\" of type ([^\\s]+)$")
+    public void pageByType(String id, String type) {
+        try {
+            Object page = Class.forName(type).newInstance();
+            pages.put(id, (WebPage) page);
+
+            if (page instanceof PageValidator) {
+                validators.put(id, (PageValidator<?>) page);
+            }
+        } catch (InstantiationException | IllegalAccessException | ClassNotFoundException e) {
+            throw new CitrusRuntimeException("Failed to load page object", e);
+        }
+    }
+
+    @Given("^(?:Browser|browser) page \"([^\"]+)\"$")
+    public void page(String id) {
+        if (!citrus.getCitrusContext().getReferenceResolver().isResolvable(id, WebPage.class)) {
+            throw new CitrusRuntimeException("Unable to find page for id: " + id);
+        }
+
+        WebPage page = citrus.getCitrusContext().getReferenceResolver().resolve(id, WebPage.class);
+        pages.put(id, page);
+
+        if (page instanceof PageValidator) {
+            validators.put(id, (PageValidator<?>) page);
+        }
+    }
+
+    @When("^(?:Browser|browser) page ([^\\s]+) performs ([^\\s]+)$")
+    public void pageAction(String pageId, String method) {
+        pageActionWithArguments(pageId, method, null);
+    }
+
+    @When("^(?:Browser|browser) page ([^\\s]+) performs ([^\\s]+) with arguments$")
+    public void pageActionWithArguments(String pageId, String method, DataTable dataTable) {
+        verifyPage(pageId);
+
+        List<String> arguments = new ArrayList<>();
+        if (dataTable != null) {
+            arguments = dataTable.asList(String.class);
+        }
+
+        runner.run(selenium().browser(browser)
+                .page(pages.get(pageId))
+                .execute(method)
+                .arguments(arguments));
+    }
+
+    @Given("^(?:Browser|browser) page validator \"([^\"]+)\"$")
+    public void pageValidator(String id) {
+        if (!citrus.getCitrusContext().getReferenceResolver().isResolvable(id, PageValidator.class)) {
+            throw new CitrusRuntimeException("Unable to find page validator for id: " + id);
+        }
+
+        validators.put(id, citrus.getCitrusContext().getReferenceResolver().resolve(id, PageValidator.class));
+    }
+
+    @Given("^(?:Browser|browser) page validator types$")
+    public void pageValidators(DataTable dataTable) {
+        Map<String, String> variables = dataTable.asMap(String.class, String.class);
+        for (Map.Entry<String, String> entry : variables.entrySet()) {
+            pageValidatorByType(entry.getKey(), entry.getValue());
+        }
+    }
+
+    @Given("^(?:Browser|browser) page validator ([^\\s]+) of type ([^\\s]+)$")
+    public void pageValidatorByType(String id, String type) {
+        try {
+            validators.put(id, (PageValidator<?>) Class.forName(type).newInstance());
+        } catch (InstantiationException | IllegalAccessException | ClassNotFoundException e) {
+            throw new CitrusRuntimeException("Failed to load page object", e);
+        }
+    }
+
+    @Then("^(?:Browser|browser) page ([^\\s]+) should validate$")
+    public void pageShouldValidate(String pageId) {
+        pageShouldValidateWithValidator(pageId, pageId);
+    }
+
+    @Then("^(?:Browser|browser) page ([^\\s]+) should validate with ([^\\s]+)$")
+    public void pageShouldValidateWithValidator(String pageId, String validatorId) {
+        verifyPage(pageId);
+
+        PageValidator<?> pageValidator = null;
+        if (validators.containsKey(validatorId)) {
+            pageValidator = validators.get(validatorId);
+        }
+
+        runner.run(selenium().browser(browser)
+                .page(pages.get(pageId))
+                .validator(pageValidator)
+                .validate());
+    }
+
+    /**
+     * Verify that page is known.
+     * @param pageId
+     */
+    private void verifyPage(String pageId) {
+        if (!pages.containsKey(pageId)) {
+            throw new CitrusRuntimeException(String.format("Unknown page '%s' - please introduce page with type information first", pageId));
+        }
+    }
+}

--- a/java/steps/yaks-selenium/src/test/java/org/citrusframework/yaks/selenium/SeleniumFeatureTest.java
+++ b/java/steps/yaks-selenium/src/test/java/org/citrusframework/yaks/selenium/SeleniumFeatureTest.java
@@ -15,15 +15,22 @@
  * limitations under the License.
  */
 
-package org.citrusframework.yaks;
+package org.citrusframework.yaks.selenium;
 
 import io.cucumber.junit.Cucumber;
 import io.cucumber.junit.CucumberOptions;
 import org.junit.runner.RunWith;
 
+/**
+ * @author Christoph Deppisch
+ */
 @RunWith(Cucumber.class)
 @CucumberOptions(
-        plugin = { "pretty", "org.citrusframework.yaks.report.TestReporter" }
+        extraGlue = {
+            "org.citrusframework.yaks.standard",
+            "org.citrusframework.yaks.http"
+        },
+        plugin = { "pretty", "com.consol.citrus.cucumber.CitrusReporter" }
 )
-public class YaksTest {
+public class SeleniumFeatureTest {
 }

--- a/java/steps/yaks-selenium/src/test/java/org/citrusframework/yaks/selenium/SeleniumStepsTest.java
+++ b/java/steps/yaks-selenium/src/test/java/org/citrusframework/yaks/selenium/SeleniumStepsTest.java
@@ -1,0 +1,294 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.yaks.selenium;
+
+import java.net.URL;
+
+import com.consol.citrus.Citrus;
+import com.consol.citrus.CitrusContext;
+import com.consol.citrus.DefaultTestCaseRunner;
+import com.consol.citrus.TestCase;
+import com.consol.citrus.TestCaseRunner;
+import com.consol.citrus.annotations.CitrusAnnotations;
+import com.consol.citrus.context.TestContext;
+import com.consol.citrus.selenium.actions.CheckInputAction;
+import com.consol.citrus.selenium.actions.ClickAction;
+import com.consol.citrus.selenium.actions.FindElementAction;
+import com.consol.citrus.selenium.actions.NavigateAction;
+import com.consol.citrus.selenium.actions.SeleniumAction;
+import com.consol.citrus.selenium.actions.SetInputAction;
+import com.consol.citrus.selenium.actions.StartBrowserAction;
+import com.consol.citrus.selenium.actions.StopBrowserAction;
+import com.consol.citrus.selenium.endpoint.SeleniumBrowser;
+import com.consol.citrus.selenium.endpoint.SeleniumBrowserConfiguration;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.chrome.ChromeDriver;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Christoph Deppisch
+ */
+public class SeleniumStepsTest {
+
+    private SeleniumSteps steps;
+
+    private TestCaseRunner runner;
+
+    private final SeleniumBrowser seleniumBrowser = Mockito.mock(SeleniumBrowser.class);
+
+    private final ChromeDriver webDriver = Mockito.mock(ChromeDriver.class);
+
+    private final Citrus citrus = Citrus.newInstance(CitrusContext.create());
+
+    @Before
+    public void injectResources() {
+        TestContext context = citrus.getCitrusContext().createTestContext();
+        steps = new SeleniumSteps();
+        runner = new DefaultTestCaseRunner(context);
+
+        CitrusAnnotations.injectAll(steps, citrus, context);
+        CitrusAnnotations.injectTestRunner(steps, runner);
+
+        citrus.getCitrusContext().bind("seleniumBrowser", seleniumBrowser);
+    }
+
+    @Test
+    public void testStart() {
+        SeleniumBrowserConfiguration endpointConfiguration = new SeleniumBrowserConfiguration();
+        when(seleniumBrowser.getName()).thenReturn("seleniumBrowser");
+        when(seleniumBrowser.getWebDriver()).thenReturn(webDriver);
+        when(seleniumBrowser.getEndpointConfiguration()).thenReturn(endpointConfiguration);
+
+        steps.setBrowser("seleniumBrowser");
+        steps.start();
+
+        TestCase testCase = runner.getTestCase();
+        Assert.assertEquals(testCase.getActionCount(), 1L);
+        Assert.assertTrue(testCase.getTestAction(0) instanceof SeleniumAction);
+        SeleniumAction action = (SeleniumAction) testCase.getTestAction(0);
+
+        Assert.assertEquals(action.getBrowser(), seleniumBrowser);
+        Assert.assertTrue(action instanceof StartBrowserAction);
+
+        verify(seleniumBrowser).start();
+    }
+
+    @Test
+    public void testStop() {
+        SeleniumBrowserConfiguration endpointConfiguration = new SeleniumBrowserConfiguration();
+        when(seleniumBrowser.getName()).thenReturn("seleniumBrowser");
+        when(seleniumBrowser.getWebDriver()).thenReturn(webDriver);
+        when(seleniumBrowser.getEndpointConfiguration()).thenReturn(endpointConfiguration);
+
+        steps.setBrowser("seleniumBrowser");
+        steps.stop();
+
+        TestCase testCase = runner.getTestCase();
+        Assert.assertEquals(testCase.getActionCount(), 1L);
+        Assert.assertTrue(testCase.getTestAction(0) instanceof SeleniumAction);
+        SeleniumAction action = (SeleniumAction) testCase.getTestAction(0);
+
+        Assert.assertEquals(action.getBrowser(), seleniumBrowser);
+        Assert.assertTrue(action instanceof StopBrowserAction);
+
+        verify(seleniumBrowser).stop();
+    }
+
+    @Test
+    public void testNavigate() {
+        SeleniumBrowserConfiguration endpointConfiguration = new SeleniumBrowserConfiguration();
+        when(seleniumBrowser.getName()).thenReturn("seleniumBrowser");
+        when(seleniumBrowser.getWebDriver()).thenReturn(webDriver);
+        when(seleniumBrowser.getEndpointConfiguration()).thenReturn(endpointConfiguration);
+
+        WebDriver.Navigation navigation = Mockito.mock(WebDriver.Navigation.class);
+        when(webDriver.navigate()).thenReturn(navigation);
+
+        steps.setBrowser("seleniumBrowser");
+        steps.navigate("http://localhost:8080/test");
+
+        TestCase testCase = runner.getTestCase();
+        Assert.assertEquals(testCase.getActionCount(), 1L);
+        Assert.assertTrue(testCase.getTestAction(0) instanceof SeleniumAction);
+        SeleniumAction action = (SeleniumAction) testCase.getTestAction(0);
+
+        Assert.assertEquals(action.getBrowser(), seleniumBrowser);
+        Assert.assertTrue(action instanceof NavigateAction);
+        Assert.assertEquals(((NavigateAction)action).getPage(), "http://localhost:8080/test");
+
+        verify(navigation).to(any(URL.class));
+    }
+
+    @Test
+    public void testClick() {
+        SeleniumBrowserConfiguration endpointConfiguration = new SeleniumBrowserConfiguration();
+        when(seleniumBrowser.getName()).thenReturn("seleniumBrowser");
+        when(seleniumBrowser.getWebDriver()).thenReturn(webDriver);
+        when(seleniumBrowser.getEndpointConfiguration()).thenReturn(endpointConfiguration);
+
+        WebElement element = Mockito.mock(WebElement.class);
+        when(element.isDisplayed()).thenReturn(true);
+        when(element.isEnabled()).thenReturn(true);
+        when(element.getTagName()).thenReturn("button");
+
+        when(webDriver.findElement(any(By.class))).thenAnswer(invocation -> {
+            By select = (By) invocation.getArguments()[0];
+
+            Assert.assertEquals(select.getClass(), By.ById.class);
+            Assert.assertEquals(select.toString(), "By.id: foo");
+            return element;
+        });
+
+        steps.setBrowser("seleniumBrowser");
+        steps.click("id", "foo");
+
+        TestCase testCase = runner.getTestCase();
+        Assert.assertEquals(testCase.getActionCount(), 1L);
+        Assert.assertTrue(testCase.getTestAction(0) instanceof SeleniumAction);
+        SeleniumAction action = (SeleniumAction) testCase.getTestAction(0);
+
+        Assert.assertEquals(action.getBrowser(), seleniumBrowser);
+        Assert.assertTrue(action instanceof ClickAction);
+        Assert.assertEquals(((ClickAction)action).getProperty(), "id");
+        Assert.assertEquals(((ClickAction)action).getPropertyValue(), "foo");
+
+        verify(element).click();
+    }
+
+    @Test
+    public void testSetInput() {
+        SeleniumBrowserConfiguration endpointConfiguration = new SeleniumBrowserConfiguration();
+        when(seleniumBrowser.getName()).thenReturn("seleniumBrowser");
+        when(seleniumBrowser.getWebDriver()).thenReturn(webDriver);
+        when(seleniumBrowser.getEndpointConfiguration()).thenReturn(endpointConfiguration);
+
+        WebElement element = Mockito.mock(WebElement.class);
+        when(element.isDisplayed()).thenReturn(true);
+        when(element.isEnabled()).thenReturn(true);
+        when(element.getTagName()).thenReturn("input");
+
+        when(webDriver.findElement(any(By.class))).thenReturn(element);
+
+        steps.setBrowser("seleniumBrowser");
+        steps.setInput("Hello","id", "foo");
+
+        TestCase testCase = runner.getTestCase();
+        Assert.assertEquals(testCase.getActionCount(), 1L);
+        Assert.assertTrue(testCase.getTestAction(0) instanceof SeleniumAction);
+        SeleniumAction action = (SeleniumAction) testCase.getTestAction(0);
+
+        Assert.assertEquals(action.getBrowser(), seleniumBrowser);
+        Assert.assertTrue(action instanceof SetInputAction);
+        Assert.assertEquals(((SetInputAction)action).getValue(), "Hello");
+        Assert.assertEquals(((SetInputAction)action).getProperty(), "id");
+        Assert.assertEquals(((SetInputAction)action).getPropertyValue(), "foo");
+
+        verify(element).clear();
+        verify(element).sendKeys("Hello");
+    }
+
+    @Test
+    public void testCheckInput() {
+        SeleniumBrowserConfiguration endpointConfiguration = new SeleniumBrowserConfiguration();
+        when(seleniumBrowser.getName()).thenReturn("seleniumBrowser");
+        when(seleniumBrowser.getWebDriver()).thenReturn(webDriver);
+        when(seleniumBrowser.getEndpointConfiguration()).thenReturn(endpointConfiguration);
+
+        WebElement element = Mockito.mock(WebElement.class);
+        when(element.isDisplayed()).thenReturn(true);
+        when(element.isEnabled()).thenReturn(true);
+        when(element.getTagName()).thenReturn("input");
+
+        when(webDriver.findElement(any(By.class))).thenReturn(element);
+
+        steps.setBrowser("seleniumBrowser");
+        steps.checkInput("checks","id", "foo");
+
+        TestCase testCase = runner.getTestCase();
+        Assert.assertEquals(testCase.getActionCount(), 1L);
+        Assert.assertTrue(testCase.getTestAction(0) instanceof SeleniumAction);
+        SeleniumAction action = (SeleniumAction) testCase.getTestAction(0);
+
+        Assert.assertEquals(action.getBrowser(), seleniumBrowser);
+        Assert.assertTrue(action instanceof CheckInputAction);
+        Assert.assertTrue(((CheckInputAction) action).isChecked());
+        Assert.assertEquals(((CheckInputAction)action).getProperty(), "id");
+        Assert.assertEquals(((CheckInputAction)action).getPropertyValue(), "foo");
+
+        verify(element).click();
+    }
+
+    @Test
+    public void testShouldDisplay() {
+        SeleniumBrowserConfiguration endpointConfiguration = new SeleniumBrowserConfiguration();
+        when(seleniumBrowser.getName()).thenReturn("seleniumBrowser");
+        when(seleniumBrowser.getWebDriver()).thenReturn(webDriver);
+        when(seleniumBrowser.getEndpointConfiguration()).thenReturn(endpointConfiguration);
+
+        WebElement element = Mockito.mock(WebElement.class);
+        when(element.isDisplayed()).thenReturn(true);
+        when(element.isEnabled()).thenReturn(true);
+        when(element.getTagName()).thenReturn("button");
+
+        when(webDriver.findElement(any(By.class))).thenAnswer(invocation -> {
+            By select = (By) invocation.getArguments()[0];
+
+            Assert.assertEquals(select.getClass(), By.ByName.class);
+            Assert.assertEquals(select.toString(), "By.name: foo");
+            return element;
+        });
+
+        steps.setBrowser("seleniumBrowser");
+        steps.shouldDisplay("name", "foo");
+
+        TestCase testCase = runner.getTestCase();
+        Assert.assertEquals(testCase.getActionCount(), 1L);
+        Assert.assertTrue(testCase.getTestAction(0) instanceof SeleniumAction);
+        SeleniumAction action = (SeleniumAction) testCase.getTestAction(0);
+
+        Assert.assertEquals(action.getBrowser(), seleniumBrowser);
+        Assert.assertTrue(action instanceof FindElementAction);
+        Assert.assertEquals(((FindElementAction)action).getProperty(), "name");
+        Assert.assertEquals(((FindElementAction)action).getPropertyValue(), "foo");
+    }
+
+    @Test
+    public void testDefaultBrowserInitialization() {
+        Assert.assertNull(steps.browser);
+        steps.before();
+        Assert.assertNotNull(steps.browser);
+    }
+
+    @Test
+    public void testBrowserInitialization() {
+        Assert.assertNull(steps.browser);
+        steps.setBrowser("seleniumBrowser");
+        steps.before();
+        Assert.assertNotNull(steps.browser);
+    }
+
+}

--- a/java/steps/yaks-selenium/src/test/java/org/citrusframework/yaks/selenium/WebServerConfiguration.java
+++ b/java/steps/yaks-selenium/src/test/java/org/citrusframework/yaks/selenium/WebServerConfiguration.java
@@ -1,0 +1,157 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.yaks.selenium;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.consol.citrus.container.AfterSuite;
+import com.consol.citrus.container.SequenceAfterSuite;
+import com.consol.citrus.context.TestContext;
+import com.consol.citrus.endpoint.EndpointAdapter;
+import com.consol.citrus.endpoint.adapter.RequestDispatchingEndpointAdapter;
+import com.consol.citrus.endpoint.adapter.StaticEndpointAdapter;
+import com.consol.citrus.endpoint.adapter.mapping.HeaderMappingKeyExtractor;
+import com.consol.citrus.endpoint.adapter.mapping.SimpleMappingStrategy;
+import com.consol.citrus.http.message.HttpMessage;
+import com.consol.citrus.http.message.HttpMessageHeaders;
+import com.consol.citrus.http.server.HttpServer;
+import com.consol.citrus.http.server.HttpServerBuilder;
+import com.consol.citrus.message.Message;
+import com.consol.citrus.selenium.endpoint.SeleniumBrowser;
+import com.consol.citrus.selenium.endpoint.SeleniumBrowserBuilder;
+import com.consol.citrus.util.FileUtils;
+import org.citrusframework.yaks.selenium.page.UserFormPage;
+import org.openqa.selenium.remote.BrowserType;
+import org.springframework.beans.factory.config.ConfigurableBeanFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.DependsOn;
+import org.springframework.context.annotation.Scope;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+
+import static com.consol.citrus.selenium.actions.SeleniumActionBuilder.selenium;
+
+/**
+ * @author Christoph Deppisch
+ */
+@Configuration
+public class WebServerConfiguration {
+
+    private static final int HTTP_PORT = 8080;
+
+    @Bean
+    public SeleniumBrowser seleniumBrowser() {
+        return new SeleniumBrowserBuilder()
+                .type(BrowserType.HTMLUNIT)
+                .build();
+    }
+
+    @Bean
+    @Scope(value = ConfigurableBeanFactory.SCOPE_PROTOTYPE)
+    public UserFormPage userForm() {
+        return new UserFormPage();
+    }
+
+    @Bean
+    public HttpServer webServer() {
+        return new HttpServerBuilder()
+                .port(HTTP_PORT)
+                .autoStart(true)
+                .endpointAdapter(templateResponseAdapter())
+                .build();
+    }
+
+    @Bean
+    @DependsOn("seleniumBrowser")
+    public AfterSuite afterSuite(SeleniumBrowser browser) {
+        return new SequenceAfterSuite() {
+            @Override
+            public void doExecute(TestContext context) {
+                selenium().browser(browser).stop()
+                        .build()
+                        .execute(context);
+            }
+        };
+    }
+
+    @Bean
+    public EndpointAdapter templateResponseAdapter() {
+        RequestDispatchingEndpointAdapter dispatchingEndpointAdapter = new RequestDispatchingEndpointAdapter();
+
+        Map<String, EndpointAdapter> mappings = new HashMap<>();
+
+        mappings.put("/", indexPageHandler());
+        mappings.put("/form", userFormPageHandler());
+        mappings.put("/favicon.ico", faviconHandler());
+
+        SimpleMappingStrategy mappingStrategy = new SimpleMappingStrategy();
+        mappingStrategy.setAdapterMappings(mappings);
+        dispatchingEndpointAdapter.setMappingStrategy(mappingStrategy);
+
+        dispatchingEndpointAdapter.setMappingKeyExtractor(new HeaderMappingKeyExtractor(HttpMessageHeaders.HTTP_REQUEST_URI));
+
+        return dispatchingEndpointAdapter;
+    }
+
+    @Bean
+    public EndpointAdapter indexPageHandler() {
+        return new StaticEndpointAdapter() {
+            @Override
+            protected Message handleMessageInternal(Message request) {
+                try {
+                    return new HttpMessage(FileUtils.readToString(new ClassPathResource("templates/index.html")))
+                            .contentType(MediaType.TEXT_HTML_VALUE)
+                            .status(HttpStatus.OK);
+                } catch (IOException e) {
+                    return new HttpMessage().status(HttpStatus.INTERNAL_SERVER_ERROR);
+                }
+            }
+        };
+    }
+
+    @Bean
+    public EndpointAdapter userFormPageHandler() {
+        return new StaticEndpointAdapter() {
+            @Override
+            protected Message handleMessageInternal(Message request) {
+                try {
+                    return new HttpMessage(FileUtils.readToString(new ClassPathResource("templates/form.html")))
+                            .contentType(MediaType.TEXT_HTML_VALUE)
+                            .status(HttpStatus.OK);
+                } catch (IOException e) {
+                    return new HttpMessage().status(HttpStatus.INTERNAL_SERVER_ERROR);
+                }
+            }
+        };
+    }
+
+    @Bean
+    public EndpointAdapter faviconHandler() {
+        return new StaticEndpointAdapter() {
+            @Override
+            protected Message handleMessageInternal(Message request) {
+                return new HttpMessage()
+                        .status(HttpStatus.OK);
+            }
+        };
+    }
+}

--- a/java/steps/yaks-selenium/src/test/java/org/citrusframework/yaks/selenium/page/UserFormPage.java
+++ b/java/steps/yaks-selenium/src/test/java/org/citrusframework/yaks/selenium/page/UserFormPage.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.yaks.selenium.page;
+
+import com.consol.citrus.context.TestContext;
+import com.consol.citrus.selenium.endpoint.SeleniumBrowser;
+import com.consol.citrus.selenium.model.PageValidator;
+import com.consol.citrus.selenium.model.WebPage;
+import org.junit.Assert;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+import org.springframework.util.StringUtils;
+
+/**
+ * @author Christoph Deppisch
+ */
+public class UserFormPage implements WebPage, PageValidator<UserFormPage> {
+
+    @FindBy(id = "userForm")
+    private WebElement form;
+
+    @FindBy(id = "username")
+    private WebElement userName;
+
+    /**
+     * Sets the user name.
+     */
+    public void setUserName(String value, TestContext context) {
+        userName.clear();
+        userName.sendKeys(value);
+    }
+
+    /**
+     * Submits the form.
+     * @param context
+     */
+    public void submit(TestContext context) {
+        form.submit();
+    }
+
+    @Override
+    public void validate(UserFormPage webPage, SeleniumBrowser browser, TestContext context) {
+        Assert.assertNotNull(userName);
+        Assert.assertTrue(StringUtils.hasText(userName.getAttribute("value")));
+        Assert.assertNotNull(form);
+    }
+}

--- a/java/steps/yaks-selenium/src/test/resources/citrus-application.properties
+++ b/java/steps/yaks-selenium/src/test/resources/citrus-application.properties
@@ -1,0 +1,19 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+citrus.spring.java.config=org.citrusframework.yaks.selenium.WebServerConfiguration
+citrus.default.message.type=JSON

--- a/java/steps/yaks-selenium/src/test/resources/cucumber.properties
+++ b/java/steps/yaks-selenium/src/test/resources/cucumber.properties
@@ -1,0 +1,19 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+cucumber.object-factory=com.consol.citrus.cucumber.backend.CitrusObjectFactory
+cucumber.publish.quiet=true

--- a/java/steps/yaks-selenium/src/test/resources/log4j2-test.xml
+++ b/java/steps/yaks-selenium/src/test/resources/log4j2-test.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements. See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<Configuration status="INFO">
+  <Appenders>
+    <Console name="STDOUT" target="SYSTEM_OUT">
+      <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss.SSS}|%-5level|%t|%c{1} - %msg%n"/>
+    </Console>
+    <Null name="NONE"/>
+  </Appenders>
+
+  <Loggers>
+    <Root level="INFO">
+      <AppenderRef ref="STDOUT"/>
+    </Root>
+
+    <!-- Our own classes-->
+    <Logger name="org.citrusframework.yaks" additivity="false" level="INFO">
+      <AppenderRef ref="STDOUT"/>
+    </Logger>
+
+    <Logger name="com.consol.citrus" additivity="false" level="INFO">
+      <AppenderRef ref="STDOUT"/>
+    </Logger>
+
+    <Logger name="Logger.Message_IN" additivity="false" level="DEBUG">
+      <AppenderRef ref="STDOUT"/>
+    </Logger>
+
+    <Logger name="Logger.Message_OUT" additivity="false" level="DEBUG">
+      <AppenderRef ref="STDOUT"/>
+    </Logger>
+
+    <Logger name="org.springframework" additivity="false" level="WARN">
+      <AppenderRef ref="STDOUT"/>
+    </Logger>
+
+    <Logger name="org.eclipse" additivity="false" level="WARN">
+      <AppenderRef ref="STDOUT"/>
+    </Logger>
+
+    <Logger name="org.apache" additivity="false" level="WARN">
+      <AppenderRef ref="STDOUT"/>
+    </Logger>
+  </Loggers>
+
+</Configuration>

--- a/java/steps/yaks-selenium/src/test/resources/org/citrusframework/yaks/selenium/selenium.feature
+++ b/java/steps/yaks-selenium/src/test/resources/org/citrusframework/yaks/selenium/selenium.feature
@@ -1,0 +1,24 @@
+Feature: Selenium feature
+
+  Background:
+    Given start browser
+
+  Scenario: Index page
+    Given user navigates to "http://localhost:8080/"
+    And browser page should display heading with tag-name="h1" having
+    | text   | Welcome!       |
+    | styles | font-size=40px |
+    And browser page should display element with id="hello-text" having
+    | text   | Hello!         |
+    | styles | background-color=rgba(0, 0, 0, 0) |
+    When user clicks element with id="open-alert"
+    And sleep 500 ms
+    Then browser page should display alert with text "Hello"
+
+  Scenario: User form page
+    Given browser page "userForm"
+    Given user navigates to "form"
+    When browser page userForm performs setUserName with arguments
+    | Christoph |
+    Then browser page userForm should validate
+    And browser page userForm performs submit

--- a/java/steps/yaks-selenium/src/test/resources/templates/form.html
+++ b/java/steps/yaks-selenium/src/test/resources/templates/form.html
@@ -1,0 +1,37 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements. See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+-->
+
+<html lang="en">
+  <body>
+    <form id="userForm" action="/" method="get">
+      <label for="username">Username</label>
+      <input id="username" type="text" />
+
+      <br/>
+
+      <label for="age">Age</label>
+      <select id="age">
+        <option value="select"></option>
+        <option value="child">0-12</option>
+        <option value="teenager">12-20</option>
+        <option value="adult">21-99</option>
+      </select>
+
+      <button type="submit">Ok</button>
+    </form>
+  </body>
+</html>

--- a/java/steps/yaks-selenium/src/test/resources/templates/index.html
+++ b/java/steps/yaks-selenium/src/test/resources/templates/index.html
@@ -1,0 +1,36 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements. See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+-->
+
+<html lang="en">
+  <head>
+    <title>Test page</title>
+    <style type="text/css">
+      #hello-text:hover {
+        background-color: #009900;
+        color: #fff;
+      }
+    </style>
+  </head>
+  <body>
+    <h1 style="font-size: 40px;">Welcome!</h1>
+
+    <p><button id="open-alert" onclick="alert('Hello');">Say Hello!</button></p>
+    <p><a name="openAlert" onclick="alert('Hello');">Say Hello!</a></p>
+
+    <span id="hello-text"><b>Hello!</b></span>
+  </body>
+</html>

--- a/pkg/apis/yaks/v1alpha1/test_types.go
+++ b/pkg/apis/yaks/v1alpha1/test_types.go
@@ -46,6 +46,7 @@ type TestSpec struct {
 	Source    SourceSpec     `json:"source,omitempty"`
 	Resources []ResourceSpec `json:"resources,omitempty"`
 	Settings  SettingsSpec   `json:"config,omitempty"`
+	Selenium  SeleniumSpec   `json:"selenium,omitempty"`
 	Env       []string       `json:"env,omitempty"`
 	Secret    string         `json:"secret,omitempty"`
 }
@@ -67,6 +68,11 @@ type ResourceSpec struct {
 type SettingsSpec struct {
 	Name    string `json:"name,omitempty"`
 	Content string `json:"content,omitempty"`
+}
+
+// SeleniumSpec--
+type SeleniumSpec struct {
+	Image string `json:"image,omitempty"`
 }
 
 // TestStatus defines the observed state of Test

--- a/pkg/cmd/config/config.go
+++ b/pkg/cmd/config/config.go
@@ -54,6 +54,7 @@ type StepConfig struct {
 
 type RuntimeConfig struct {
     Cucumber  CucumberConfig `yaml:"cucumber"`
+    Selenium  SeleniumConfig `yaml:"selenium"`
     Resources []string 	     `yaml:"resources"`
     Settings  SettingsConfig `yaml:"settings"`
     Env 	  []EnvConfig 	 `yaml:"env"`
@@ -64,6 +65,10 @@ type CucumberConfig struct {
     Tags    []string `yaml:"tags"`
     Glue    []string `yaml:"glue"`
     Options string   `yaml:"options"`
+}
+
+type SeleniumConfig struct {
+    Image           string `yaml:"image"`
 }
 
 type EnvConfig struct {

--- a/pkg/cmd/test.go
+++ b/pkg/cmd/test.go
@@ -468,6 +468,12 @@ func (o *testCmdOptions) createAndRunTest(c client.Client, rawName string, runCo
 		test.Spec.Secret = runConfig.Config.Runtime.Secret;
 	}
 
+	if runConfig.Config.Runtime.Selenium.Image != "" {
+		test.Spec.Selenium = v1alpha1.SeleniumSpec{
+			Image: runConfig.Config.Runtime.Selenium.Image,
+		};
+	}
+
 	switch o.DumpFormat {
 		case "":
 			// continue..


### PR DESCRIPTION
- Use Selenium standalone as sidecar container and connect via remote driver to execute UI tests
- Terminate sidecar after test run via supervisord shutdown via SIGTERM signal
- Use integration-test phase in Maven yaks-runtime in order to shutdown selenium sidecar after tests (post-integration-test phase)