### PR TITLE
Add new commands

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -119,28 +119,28 @@ jobs:
         yaks install --operator-image $YAKS_IMAGE_NAME:$YAKS_IMAGE_VERSION
     - name: E2E Tests
       run: |
-        # Eventually `yaks test examples` should work
+        # Eventually `yaks run examples` should work
 
         # For now:
-        yaks test examples/camel
-        yaks test examples/camel-k
-        #yaks test examples/extension
-        yaks test examples/http
-        #yaks test examples/jdbc
-        yaks test examples/jitpack
-        #yaks test examples/kamelets
-        #yaks test examples/knative
-        yaks test examples/kubernetes
-        yaks test examples/logging
-        yaks test examples/namespace
-        yaks test examples/openapi
-        yaks test examples/openapi-server
-        yaks test examples/run-scripts
-        #yaks test examples/secrets
-        yaks test examples/settings
-        yaks test examples/test-group
-        yaks test examples/helloworld.feature
-        yaks test examples/selenium
+        yaks run examples/camel
+        yaks run examples/camel-k
+        #yaks run examples/extension
+        yaks run examples/http
+        #yaks run examples/jdbc
+        yaks run examples/jitpack
+        #yaks run examples/kamelets
+        #yaks run examples/knative
+        yaks run examples/kubernetes
+        yaks run examples/logging
+        yaks run examples/namespace
+        yaks run examples/openapi
+        yaks run examples/openapi-server
+        yaks run examples/run-scripts
+        #yaks run examples/secrets
+        yaks run examples/settings
+        yaks run examples/test-group
+        yaks run examples/helloworld.feature
+        yaks run examples/selenium
 
   snapshot:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Feature: Hello
 You can then execute the following command using the [YAKS CLI tool](https://github.com/citrusframework/yaks/releases/):
 
 ```bash
-yaks test helloworld.feature
+yaks run helloworld.feature
 ```
 
 This runs the test immediately on the current namespace in your connected Kubernetes cluster.

--- a/examples/extension/README.md
+++ b/examples/extension/README.md
@@ -43,13 +43,13 @@ The additional glue code should match the package name where to find the custom 
 With that you are all set and can run the test as usual:
 
 ```shell script
-$ yaks test extension.feature
+$ yaks run extension.feature
 ```
 
 You can also use the upload as part of the test command:
 
 ```shell script
-$ yaks test extension.feature --upload steps
+$ yaks run extension.feature --upload steps
 ```                                         
 
 The `--upload` option builds and uploads the custom Maven module automatically before the test.

--- a/examples/jitpack/README.md
+++ b/examples/jitpack/README.md
@@ -45,7 +45,7 @@ Maven repository makes sure the library gets resolved at runtime.
 With that you are all set and can run the test as usual:
 
 ```shell script
-$ yaks test jitpack.feature
+$ yaks run jitpack.feature
 ```
 
 In the logs you will see that Jitpack automatically loads the additional dependency before the test.

--- a/examples/kamelets/README.md
+++ b/examples/kamelets/README.md
@@ -10,7 +10,7 @@ Camel-K integration.
 
 [kamelet.feature](kamelet.feature)
 ```shell script
-$ yaks test examples/kamelets/kamelet.feature
+$ yaks run examples/kamelets/kamelet.feature
 ```
 
 ## Create Kamelets using file resources
@@ -29,7 +29,7 @@ config:
 
 [kamelet-resource.feature](kamelet-resource.feature)
 ```shell script
-$ yaks test examples/kamelets/kamelet-resource.feature
+$ yaks run examples/kamelets/kamelet-resource.feature
 ```             
 
 The test is able to load the Kamelet using the external file resource. Also the Camel-K integration code
@@ -38,7 +38,7 @@ is loaded from a file resource in this example.
 You could also specify files to load in the command line
 
 ```shell script
-$ yaks test examples/kamelets/kamelet-resource.feature \
+$ yaks run examples/kamelets/kamelet-resource.feature \
             --resource timer-to-log.groovy \
             --resource timer-source.kamelet.yaml
 ``` 

--- a/examples/settings/README.md
+++ b/examples/settings/README.md
@@ -113,5 +113,5 @@ config:
 With this configuration in place you can just run the test and the settings file will be added automatically.
 
 ```shell script
-$ yaks test camel-route.feature
+$ yaks run camel-route.feature
 ```

--- a/java/docs/cli.adoc
+++ b/java/docs/cli.adoc
@@ -30,12 +30,20 @@ Some of the most used commands are:
 |Install YAKS operator and setup cluster (roles, CRDs)
 |`yaks install`
 
-|test
-|Run a test on Kubernetes
-|`yaks test helloworld.feature`
+|list
+|List the results of all tests on given namespace
+|`yaks list`
+
+|run
+|Deploys and executes a test on given namespace
+|`yaks run helloworld.feature`
+
+|delete
+|Delete tests by name from given namespace
+|`yaks delete helloworld.feature`
 
 |report
-|Fetches and generates reports from test results
+|Fetch and generate reports from test results
 |`yaks report --fetch -o junit`
 
 |upload
@@ -70,10 +78,12 @@ Usage:
 
 Available Commands:
   completion  Generates completion scripts
+  delete      Delete tests
   help        Help about any command
   install     Installs YAKS on a Kubernetes cluster
+  list        List tests
   report      Generate test report from last test run
-  test        Execute a test on Kubernetes
+  run         Run tests
   uninstall   Uninstall YAKS from a Kubernetes cluster
   upload      Upload a local test artifact to the cluster
   version     Display version information
@@ -89,7 +99,7 @@ Use "yaks [command] --help" for more information about a command.
 .Command help
 [source, shell script]
 ----
-yaks test --help
+yaks run --help
 ----
 
 [[cli-install]]
@@ -100,17 +110,37 @@ The command `install` performs the YAKS installation on a target cluster. The co
 . Setup cluster resources (CRDs, roles, rolebindings)
 . Install YAKS operator to current namespace (or to the provided namespace in settings)
 
-[[cli-test]]
-== test
+[[cli-list]]
+== list
+
+TODO
+
+[[cli-run]]
+== run
+
+TODO
+
+[[cli-delete]]
+== delete
+
+TODO
 
 [[cli-report]]
 == report
 
+TODO
+
 [[cli-upload]]
 == upload
+
+TODO
 
 [[cli-uninstall]]
 == uninstall
 
+TODO
+
 [[cli-version]]
 == version
+
+TODO

--- a/java/docs/cli.adoc
+++ b/java/docs/cli.adoc
@@ -82,6 +82,7 @@ Available Commands:
   help        Help about any command
   install     Installs YAKS on a Kubernetes cluster
   list        List tests
+  log         Print the logs of given test
   report      Generate test report from last test run
   run         Run tests
   uninstall   Uninstall YAKS from a Kubernetes cluster
@@ -122,6 +123,11 @@ TODO
 
 [[cli-delete]]
 == delete
+
+TODO
+
+[[cli-logs]]
+== log
 
 TODO
 

--- a/java/docs/configuration.adoc
+++ b/java/docs/configuration.adoc
@@ -33,7 +33,7 @@ Also we can make use of command line options when using the `yaks` binary.
 
 [source,shell script]
 ----
-yaks test hello-world.feature --tag @regression --glue org.citrusframework.yaks
+yaks run hello-world.feature --tag @regression --glue org.citrusframework.yaks
 ----
 
 [[configuration-dependencies]]
@@ -96,7 +96,7 @@ You can add dependencies also by specifying the dependencies as command line par
 
 [source,shell script]
 ----
-yaks test --dependency org.apache.camel:camel-groovy:@camel.version@ camel-route.feature
+yaks run --dependency org.apache.camel:camel-groovy:@camel.version@ camel-route.feature
 ----
 
 This will add a environment setting in the YAKS runtime container and the dependency will be loaded automatically
@@ -119,7 +119,7 @@ You can add the property file when running the test via `yaks` CLI like follows:
 
 [source,shell script]
 ----
-yaks test --settings yaks.properties camel-route.feature
+yaks run --settings yaks.properties camel-route.feature
 ----
 
 [[configuration-file]]
@@ -162,7 +162,7 @@ You can add the configuration file when running the test via `yaks` CLI like fol
 
 [source,shell script]
 ----
-yaks test --settings yaks.settings.yaml camel-route.feature
+yaks run --settings yaks.settings.yaml camel-route.feature
 ----
 
 [[configuration-repositories]]
@@ -180,7 +180,7 @@ You can add repositories also by specifying the repositories as command line par
 
 [source,shell script]
 ----
-yaks test --maven-repository jboss-ea=https://repository.jboss.org/nexus/content/groups/ea/ my.feature
+yaks run --maven-repository jboss-ea=https://repository.jboss.org/nexus/content/groups/ea/ my.feature
 ----
 
 This will add a environment setting in the YAKS runtime container and the repository will be added to the Maven runtime project model.
@@ -202,7 +202,7 @@ You can add the property file when running the test via `yaks` CLI like follows:
 
 [source,shell script]
 ----
-yaks test --settings yaks.properties my.feature
+yaks run --settings yaks.properties my.feature
 ----
 
 [[configuration-repository-config]]
@@ -259,7 +259,7 @@ You can add the configuration file when running the test via `yaks` CLI like fol
 
 [source,shell script]
 ----
-yaks test --settings yaks.settings.yaml my.feature
+yaks run --settings yaks.settings.yaml my.feature
 ----
 
 [[configuration-secrets]]

--- a/java/docs/extensions.adoc
+++ b/java/docs/extensions.adoc
@@ -50,14 +50,14 @@ With that you are all set and can run the test as usual:
 
 [source,shell script]
 ----
-$ yaks test extension.feature
+$ yaks run extension.feature
 ----
 
 You can also use the upload as part of the test command:
 
 [source,shell script]
 ----
-$ yaks test extension.feature --upload steps
+$ yaks run extension.feature --upload steps
 ----
 
 The `--upload` option builds and uploads the custom Maven module automatically before the test.
@@ -111,7 +111,7 @@ With that you are all set and can run the test as usual:
 
 [source,shell script]
 ----
-$ yaks test jitpack.feature
+$ yaks run jitpack.feature
 ----
 
 In the logs you will see that Jitpack automatically loads the additional dependency before the test.

--- a/java/docs/quickstart.adoc
+++ b/java/docs/quickstart.adoc
@@ -17,7 +17,7 @@ You can then execute the following command using the https://github.com/citrusfr
 
 [source,shell script]
 ----
-yaks test helloworld.feature
+yaks run helloworld.feature
 ----
 
 This runs the test immediately on the current namespace in your connected Kubernetes cluster.

--- a/java/docs/running.adoc
+++ b/java/docs/running.adoc
@@ -36,7 +36,7 @@ You just need this single file to run the test on the cluster.
 
 [source,shell script]
 ----
-yaks test helloworld.feature
+yaks run helloworld.feature
 ----
 
 You will be provided with the log output of the test and see the results:
@@ -88,7 +88,7 @@ with the command line option `--logger`.
 
 [source,shell script]
 ----
-yaks test helloworld.feature --logger root=INFO
+yaks run helloworld.feature --logger root=INFO
 ----
 
 The link:#logging[logging configuration] section in thi guide gives you some more details on this topic.

--- a/java/docs/steps-custom.adoc
+++ b/java/docs/steps-custom.adoc
@@ -13,7 +13,7 @@ To run the example:
 
 [source]
 ----
-yaks test extension.feature -u steps/
+yaks run extension.feature -u steps/
 ----
 
 The `-u` flag stands for "upload". The steps project is built before running the test and the artifacts are uploaded to a

--- a/pkg/cmd/delete.go
+++ b/pkg/cmd/delete.go
@@ -39,9 +39,11 @@ func newCmdDelete(rootCmdOptions *RootCmdOptions) (*cobra.Command, *deleteCmdOpt
 		Use:     "delete [test1] [test2] ...",
 		Short:   "Delete tests",
 		Long:    "Delete tests by name from given namespace.",
-		Args:    options.validateArgs,
 		PreRunE: decode(&options),
-		RunE: func(_ *cobra.Command, args []string) error {
+		RunE: func(command *cobra.Command, args []string) error {
+			if err := options.validateArgs(command, args); err != nil {
+				return err
+			}
 			if err := options.run(args); err != nil {
 				fmt.Println(err.Error())
 			}
@@ -50,7 +52,7 @@ func newCmdDelete(rootCmdOptions *RootCmdOptions) (*cobra.Command, *deleteCmdOpt
 		},
 	}
 
-	cmd.Flags().Bool("all", false, "Delete all tests")
+	cmd.Flags().BoolP("all", "a", false, "Delete all tests")
 
 	return &cmd, &options
 }

--- a/pkg/cmd/delete.go
+++ b/pkg/cmd/delete.go
@@ -1,0 +1,136 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"github.com/citrusframework/yaks/pkg/apis/yaks/v1alpha1"
+	"github.com/citrusframework/yaks/pkg/util/kubernetes"
+	"strconv"
+
+	"github.com/spf13/cobra"
+	k8errors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// newCmdDelete --
+func newCmdDelete(rootCmdOptions *RootCmdOptions) (*cobra.Command, *deleteCmdOptions) {
+	options := deleteCmdOptions{
+		RootCmdOptions: rootCmdOptions,
+	}
+	cmd := cobra.Command{
+		Use:     "delete [test1] [test2] ...",
+		Short:   "Delete tests",
+		Long:    "Delete tests by name from given namespace.",
+		Args:    options.validateArgs,
+		PreRunE: decode(&options),
+		RunE: func(_ *cobra.Command, args []string) error {
+			if err := options.run(args); err != nil {
+				fmt.Println(err.Error())
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().Bool("all", false, "Delete all tests")
+
+	return &cmd, &options
+}
+
+type deleteCmdOptions struct {
+	*RootCmdOptions
+	DeleteAll bool `mapstructure:"all"`
+}
+
+func (o *deleteCmdOptions) validateArgs(_ *cobra.Command, args []string) error {
+	if o.DeleteAll && len(args) > 0 {
+		return errors.New("invalid combination: both all flag and named tests are set")
+	}
+
+	if !o.DeleteAll && len(args) == 0 {
+		return errors.New("invalid combination: neither all flag nor named tests are set")
+	}
+
+	return nil
+}
+
+func (o *deleteCmdOptions) run(args []string) error {
+	c, err := o.GetCmdClient()
+	if err != nil {
+		return err
+	}
+
+	namespace := o.Namespace
+
+	if len(args) != 0 && !o.DeleteAll {
+		for _, arg := range args {
+			name := kubernetes.SanitizeName(arg)
+
+			test := v1alpha1.Test{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: v1alpha1.SchemeGroupVersion.String(),
+					Kind:       v1alpha1.TestKind,
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: namespace,
+					Name:      name,
+				},
+			}
+			err := c.Delete(o.Context, &test)
+			if err != nil {
+				if k8errors.IsNotFound(err) {
+					fmt.Println("Test " + name + " not found. Skipped.")
+				} else {
+					return err
+				}
+			} else {
+				fmt.Println("Test " + name + " deleted")
+			}
+		}
+	} else if o.DeleteAll {
+		testList := v1alpha1.TestList{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: v1alpha1.SchemeGroupVersion.String(),
+				Kind:       v1alpha1.TestKind,
+			},
+		}
+
+		//Looks like Operator SDK doesn't support deletion of all objects with one command
+		err := c.List(o.Context, &testList, k8sclient.InNamespace(namespace))
+		if err != nil {
+			return err
+		}
+		for _, test := range testList.Items {
+			test := test // pin
+			err := c.Delete(o.Context, &test)
+			if err != nil {
+				return err
+			}
+		}
+		if len(testList.Items) == 0 {
+			fmt.Printf("No tests found in %s namespace.\n", namespace)
+		} else {
+			fmt.Println(strconv.Itoa(len(testList.Items)) + " test(s) deleted")
+		}
+	}
+
+	return nil
+}

--- a/pkg/cmd/list.go
+++ b/pkg/cmd/list.go
@@ -1,0 +1,92 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"fmt"
+	"github.com/citrusframework/yaks/pkg/apis/yaks/v1alpha1"
+	"text/tabwriter"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/spf13/cobra"
+)
+
+type getCmdOptions struct {
+	*RootCmdOptions
+}
+
+func newCmdList(rootCmdOptions *RootCmdOptions) (*cobra.Command, *getCmdOptions) {
+	options := getCmdOptions{
+		RootCmdOptions: rootCmdOptions,
+	}
+	cmd := cobra.Command{
+		Use:     "list",
+		Short:   "List tests",
+		Long:    `List the results of all tests on given namespace.`,
+		Aliases: []string{"ls"},
+		PreRunE: decode(&options),
+		RunE:    options.run,
+	}
+
+	return &cmd, &options
+}
+
+func (o *getCmdOptions) run(cmd *cobra.Command, args []string) error {
+	c, err := o.GetCmdClient()
+	if err != nil {
+		return err
+	}
+
+	testList := v1alpha1.TestList{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: v1alpha1.SchemeGroupVersion.String(),
+			Kind:       v1alpha1.TestKind,
+		},
+	}
+
+	namespace := o.Namespace
+
+	options := []k8sclient.ListOption{
+		k8sclient.InNamespace(namespace),
+	}
+
+	err = c.List(o.Context, &testList, options...)
+	if err != nil {
+		return err
+	}
+
+	if len(testList.Items) == 0 {
+		fmt.Printf("No tests found in %s namespace.\n", namespace)
+		return nil
+	}
+
+	w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 8, 1, '\t', 0)
+	fmt.Fprintln(w, "NAME\tPHASE\tTOTAL\tPASSED\tFAILED\tSKIPPED\tERRORS")
+	for _, test := range testList.Items {
+		fmt.Fprintf(w, "%s\t%s\t%d\t%d\t%d\t%d\t%d\n", test.Name, string(test.Status.Phase),
+			test.Status.Results.Summary.Total,
+			test.Status.Results.Summary.Passed,
+			test.Status.Results.Summary.Failed,
+			test.Status.Results.Summary.Skipped,
+			test.Status.Results.Summary.Errors)
+	}
+	return w.Flush()
+}

--- a/pkg/cmd/log.go
+++ b/pkg/cmd/log.go
@@ -1,0 +1,239 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"github.com/citrusframework/yaks/pkg/apis/yaks/v1alpha1"
+	"github.com/citrusframework/yaks/pkg/client"
+	"github.com/citrusframework/yaks/pkg/cmd/config"
+	"github.com/citrusframework/yaks/pkg/util/kubernetes"
+	"io"
+	corev1 "k8s.io/api/core/v1"
+	"time"
+
+	k8slog "github.com/citrusframework/yaks/pkg/util/kubernetes/log"
+	"github.com/spf13/cobra"
+	k8errors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func newCmdLog(rootCmdOptions *RootCmdOptions) (*cobra.Command, *logCmdOptions) {
+	options := logCmdOptions{
+		RootCmdOptions: rootCmdOptions,
+	}
+
+	cmd := cobra.Command{
+		Use:     "log [test]",
+		Short:   "Print the logs of given test",
+		Long:    `Print the logs of given test.`,
+		Aliases: []string{"logs"},
+		Args:    options.validateArgs,
+		PreRunE: decode(&options),
+		RunE:    options.run,
+	}
+
+	cmd.Flags().String("timeout", "", "Time to wait for individual logs")
+
+	return &cmd, &options
+}
+
+type logCmdOptions struct {
+	*RootCmdOptions
+	Timeout string `mapstructure:"timeout"`
+}
+
+func (o *logCmdOptions) validateArgs(_ *cobra.Command, args []string) error {
+	if len(args) != 1 {
+		return errors.New("log expects a test name as argument")
+	}
+
+	return nil
+}
+
+func (o *logCmdOptions) run(cmd *cobra.Command, args []string) error {
+	c, err := o.GetCmdClient()
+	if err != nil {
+		return err
+	}
+
+	name := args[0]
+
+	test := v1alpha1.Test{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       v1alpha1.TestKind,
+			APIVersion: v1alpha1.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: o.Namespace,
+			Name:      name,
+		},
+	}
+	key := k8sclient.ObjectKey{
+		Namespace: o.Namespace,
+		Name:      name,
+	}
+
+	var timeout string
+	if o.Timeout != "" {
+		timeout = o.Timeout
+	} else {
+		timeout = config.DefaultTimeout
+	}
+
+	waitTimeout, parseErr := time.ParseDuration(timeout)
+	if parseErr != nil {
+		fmt.Println(fmt.Sprintf("failed to parse test timeout setting - %s", parseErr.Error()))
+		waitTimeout, _ = time.ParseDuration(config.DefaultTimeout)
+	}
+
+	var pollInterval = 2 * time.Second
+	var currLogMsg = ""
+	var newLogMsg = ""
+
+	ctx, cancel := context.WithCancel(o.Context)
+	err = wait.PollImmediate(pollInterval, waitTimeout, func() (done bool, err error) {
+
+		//
+		// Reduce repetition of messages by tracking the last message
+		// and checking if its different from the new message
+		//
+		if newLogMsg != currLogMsg {
+			fmt.Println(newLogMsg)
+			currLogMsg = newLogMsg
+		}
+
+		//
+		// Try and find the test
+		//
+		err = c.Get(ctx, key, &test)
+		if err != nil && !k8errors.IsNotFound(err) {
+			// different error so return
+			return false, err
+		}
+
+		if k8errors.IsNotFound(err) {
+			//
+			// Don't have an integration yet so log and wait
+			//
+			newLogMsg = fmt.Sprintf("Test '%s' not yet available. Waiting ...", name)
+			return false, nil
+		}
+
+		//
+		// Found the integration so check its status using its phase
+		//
+		phase := test.Status.Phase
+		switch phase {
+		case v1alpha1.TestPhaseRunning:
+			go func() {
+				err = kubernetes.WaitCondition(o.Context, c, &test, func(obj interface{}) (bool, error) {
+					if val, ok := obj.(*v1alpha1.Test); ok {
+						if val.Status.Phase == v1alpha1.TestPhaseDeleting ||
+							val.Status.Phase == v1alpha1.TestPhaseError ||
+							val.Status.Phase == v1alpha1.TestPhasePassed ||
+							val.Status.Phase == v1alpha1.TestPhaseFailed {
+							return true, nil
+						}
+					}
+					return false, nil
+				}, waitTimeout)
+
+				cancel()
+			}()
+
+			//
+			// Found the running test so step over to scraping its pod log
+			//
+			fmt.Printf("Test '%s' is now running. Showing log ...\n", name)
+			if err := k8slog.Print(ctx, c, o.Namespace, name, cmd.OutOrStdout()); err != nil {
+				return false, err
+			} else {
+				return true, nil
+			}
+		case v1alpha1.TestPhasePassed, v1alpha1.TestPhaseFailed, v1alpha1.TestPhaseError:
+			//
+			// Test is finished or even in error
+			//
+			fmt.Printf("Test '%s' is finished. Showing logs ...\n", name)
+			if err := printLogs(ctx, c, o.Namespace, name, test.Status.TestID, cmd.OutOrStdout()); err != nil {
+				return false, err
+			} else {
+				cancel()
+				return true, nil
+			}
+		default:
+			//
+			// Test is new or still pending
+			//
+			newLogMsg = fmt.Sprintf("Test '%s' is in phase: %s ...", name, phase)
+		}
+
+		return false, nil
+	})
+
+	if err != nil {
+		return err
+	}
+
+	// Let's add a wait point, otherwise the script terminates
+	<-ctx.Done()
+
+	return nil
+}
+
+func printLogs(ctx context.Context, c client.Client, namespace string, name string, testId string, out io.Writer) error {
+	pods, err := c.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: v1alpha1.TestIdLabel + "=" + testId,
+	})
+
+	if pods == nil || len(pods.Items) == 0 {
+		return errors.New(fmt.Sprintf("unable to locate test pod for name %s in namespace %s", name, namespace))
+	}
+
+	logOptions := corev1.PodLogOptions{
+		Follow:    false,
+		Container: "test",
+	}
+	byteReader, err := c.CoreV1().Pods(namespace).GetLogs(pods.Items[0].Name, &logOptions).Stream(ctx)
+	if err != nil {
+		return err
+	}
+
+	reader := bufio.NewReader(byteReader)
+	for {
+		data, err := reader.ReadBytes('\n')
+		if err == io.EOF {
+			return nil
+		}
+		if err != nil {
+			break
+		}
+		_, err = out.Write(data)
+		if err != nil {
+			break
+		}
+	}
+
+	return nil
+}

--- a/pkg/cmd/report.go
+++ b/pkg/cmd/report.go
@@ -31,24 +31,24 @@ func newCmdReport(rootCmdOptions *RootCmdOptions) (*cobra.Command, *reportCmdOpt
 	}
 
 	cmd := cobra.Command{
-		Use:               "report [options]",
-		Short:             "Generate test report from last test run",
-		Long:              `Generate test report from last test run. Test results are fetched from cluster and/or collected from local test output.`,
-		PreRunE:           decode(&options),
-		RunE:              options.run,
+		Use:     "report [options]",
+		Short:   "Generate test report from last test run",
+		Long:    `Generate test report holding results from last test run. Fetch results from cluster and/or collect from local test output.`,
+		PreRunE: decode(&options),
+		RunE:    options.run,
 	}
 
 	cmd.Flags().Bool("fetch", false, "Fetch latest test results from cluster.")
-	cmd.Flags().StringP( "output", "o", "summary", "The report output format, one of 'summary', 'json', 'junit'")
-	cmd.Flags().BoolP( "clean", "c", false,"Clean the report output folder before fetching results")
+	cmd.Flags().StringP("output", "o", "summary", "The report output format, one of 'summary', 'json', 'junit'")
+	cmd.Flags().BoolP("clean", "c", false, "Clean the report output folder before fetching results")
 
 	return &cmd, &options
 }
 
 type reportCmdOptions struct {
 	*RootCmdOptions
-	Clean 		 bool	`mapstructure:"clean"`
-	Fetch 		 bool	`mapstructure:"fetch"`
+	Clean        bool                `mapstructure:"clean"`
+	Fetch        bool                `mapstructure:"fetch"`
 	OutputFormat report.OutputFormat `mapstructure:"output"`
 }
 
@@ -81,7 +81,7 @@ func (o *reportCmdOptions) run(cmd *cobra.Command, _ []string) error {
 func (o *reportCmdOptions) FetchResults() (*v1alpha1.TestResults, error) {
 	c, err := o.GetCmdClient()
 	if err != nil {
-		return nil, err;
+		return nil, err
 	}
 
 	if o.Clean {

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -73,6 +73,7 @@ func NewYaksCommand(ctx context.Context) (*cobra.Command, error) {
 	cmd.AddCommand(cmdOnly(newCmdRun(&options)))
 	cmd.AddCommand(cmdOnly(newCmdDelete(&options)))
 	cmd.AddCommand(cmdOnly(newCmdList(&options)))
+	cmd.AddCommand(cmdOnly(newCmdLog(&options)))
 	cmd.AddCommand(cmdOnly(newCmdInstall(&options)))
 	cmd.AddCommand(cmdOnly(newCmdUninstall(&options)))
 	cmd.AddCommand(newCmdOperator())

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -71,6 +71,7 @@ func NewYaksCommand(ctx context.Context) (*cobra.Command, error) {
 	cmd.AddCommand(newCmdCompletion(&cmd))
 	cmd.AddCommand(newCmdVersion())
 	cmd.AddCommand(cmdOnly(newCmdTest(&options)))
+	cmd.AddCommand(cmdOnly(newCmdDelete(&options)))
 	cmd.AddCommand(cmdOnly(newCmdInstall(&options)))
 	cmd.AddCommand(cmdOnly(newCmdUninstall(&options)))
 	cmd.AddCommand(newCmdOperator())

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -70,7 +70,7 @@ func NewYaksCommand(ctx context.Context) (*cobra.Command, error) {
 
 	cmd.AddCommand(newCmdCompletion(&cmd))
 	cmd.AddCommand(newCmdVersion())
-	cmd.AddCommand(cmdOnly(newCmdTest(&options)))
+	cmd.AddCommand(cmdOnly(newCmdRun(&options)))
 	cmd.AddCommand(cmdOnly(newCmdDelete(&options)))
 	cmd.AddCommand(cmdOnly(newCmdList(&options)))
 	cmd.AddCommand(cmdOnly(newCmdInstall(&options)))

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -33,7 +33,7 @@ const (
 	ConfigPathEnv = "YAKS_CONFIG_PATH"
 
 	commandShortDescription = `YAKS is a client tool for running tests natively on Kubernetes`
-	commandLongDescription = `YAKS is a platform to enable Cloud Native BDD testing on Kubernetes.`
+	commandLongDescription  = `YAKS is a platform to enable Cloud Native BDD testing on Kubernetes.`
 )
 
 // RootCmdOptions --
@@ -59,10 +59,10 @@ func NewYaksCommand(ctx context.Context) (*cobra.Command, error) {
 	var cmd = cobra.Command{
 		BashCompletionFunction: bashCompletionFunction,
 		PersistentPreRunE:      options.preRun,
-		Use:   "yaks",
-		Short: commandShortDescription,
-		Long:  commandLongDescription,
-		SilenceUsage: true,
+		Use:                    "yaks",
+		Short:                  commandShortDescription,
+		Long:                   commandLongDescription,
+		SilenceUsage:           true,
 	}
 
 	cmd.PersistentFlags().StringVar(&options.KubeConfig, "config", os.Getenv("KUBECONFIG"), "Path to the config file to use for CLI requests")
@@ -72,6 +72,7 @@ func NewYaksCommand(ctx context.Context) (*cobra.Command, error) {
 	cmd.AddCommand(newCmdVersion())
 	cmd.AddCommand(cmdOnly(newCmdTest(&options)))
 	cmd.AddCommand(cmdOnly(newCmdDelete(&options)))
+	cmd.AddCommand(cmdOnly(newCmdList(&options)))
 	cmd.AddCommand(cmdOnly(newCmdInstall(&options)))
 	cmd.AddCommand(cmdOnly(newCmdUninstall(&options)))
 	cmd.AddCommand(newCmdOperator())

--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -36,8 +36,8 @@ import (
 	"github.com/citrusframework/yaks/pkg/cmd/config"
 	"github.com/citrusframework/yaks/pkg/cmd/report"
 	"github.com/citrusframework/yaks/pkg/util/kubernetes"
-	"github.com/citrusframework/yaks/pkg/util/openshift"
 	k8slog "github.com/citrusframework/yaks/pkg/util/kubernetes/log"
+	"github.com/citrusframework/yaks/pkg/util/openshift"
 	"github.com/google/uuid"
 	projectv1 "github.com/openshift/api/project/v1"
 	"github.com/pkg/errors"
@@ -46,7 +46,6 @@ import (
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime/pkg/client"
-
 )
 
 const (
@@ -55,10 +54,10 @@ const (
 )
 
 const (
-	NamespaceEnv       = "YAKS_NAMESPACE"
-	RepositoriesEnv    = "YAKS_REPOSITORIES"
-	DependenciesEnv    = "YAKS_DEPENDENCIES"
-	LoggersEnv         = "YAKS_LOGGERS"
+	NamespaceEnv    = "YAKS_NAMESPACE"
+	RepositoriesEnv = "YAKS_REPOSITORIES"
+	DependenciesEnv = "YAKS_DEPENDENCIES"
+	LoggersEnv      = "YAKS_LOGGERS"
 
 	CucumberOptions    = "CUCUMBER_OPTIONS"
 	CucumberGlue       = "CUCUMBER_GLUE"
@@ -66,18 +65,19 @@ const (
 	CucumberFilterTags = "CUCUMBER_FILTER_TAGS"
 )
 
-func newCmdTest(rootCmdOptions *RootCmdOptions) (*cobra.Command, *testCmdOptions) {
-	options := testCmdOptions{
+func newCmdRun(rootCmdOptions *RootCmdOptions) (*cobra.Command, *runCmdOptions) {
+	options := runCmdOptions{
 		RootCmdOptions: rootCmdOptions,
 	}
 
 	cmd := cobra.Command{
-		Use:             "test [options] [test file to execute]",
-		Short:           "Execute a test on Kubernetes",
-		Long:            `Deploys and executes a test on Kubernetes.`,
-		Args:            options.validateArgs,
-		PreRunE:         decode(&options),
-		RunE:            options.run,
+		Use:     "run [options] [test file to execute]",
+		Short:   "Run tests",
+		Long:    `Deploys and executes a test on given namespace.`,
+		Args:    options.validateArgs,
+		Aliases: []string{"test"},
+		PreRunE: decode(&options),
+		RunE:    options.run,
 	}
 
 	cmd.Flags().StringArray("maven-repository", nil, "Adds custom Maven repository URL that is added to the runtime.")
@@ -99,7 +99,7 @@ func newCmdTest(rootCmdOptions *RootCmdOptions) (*cobra.Command, *testCmdOptions
 	return &cmd, &options
 }
 
-type testCmdOptions struct {
+type runCmdOptions struct {
 	*RootCmdOptions
 	Repositories  []string            `mapstructure:"maven-repository"`
 	Dependencies  []string            `mapstructure:"dependency"`
@@ -118,7 +118,7 @@ type testCmdOptions struct {
 	Timeout       string              `mapstructure:"timeout"`
 }
 
-func (o *testCmdOptions) validateArgs(_ *cobra.Command, args []string) error {
+func (o *runCmdOptions) validateArgs(_ *cobra.Command, args []string) error {
 	if len(args) != 1 {
 		return errors.New(fmt.Sprintf("accepts exactly 1 test name to execute, received %d", len(args)))
 	}
@@ -126,7 +126,7 @@ func (o *testCmdOptions) validateArgs(_ *cobra.Command, args []string) error {
 	return nil
 }
 
-func (o *testCmdOptions) run(cmd *cobra.Command, args []string) error {
+func (o *runCmdOptions) run(cmd *cobra.Command, args []string) error {
 	source := args[0]
 
 	results := v1alpha1.TestResults{}
@@ -148,7 +148,7 @@ func (o *testCmdOptions) run(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func (o *testCmdOptions) runTest(cmd *cobra.Command, source string, results *v1alpha1.TestResults) {
+func (o *runCmdOptions) runTest(cmd *cobra.Command, source string, results *v1alpha1.TestResults) {
 	c, err := o.GetCmdClient()
 	if err != nil {
 		handleTestError("", source, results, err)
@@ -192,7 +192,7 @@ func (o *testCmdOptions) runTest(cmd *cobra.Command, source string, results *v1a
 	var test *v1alpha1.Test
 	test, err = o.createAndRunTest(cmd, c, source, runConfig)
 	if test != nil {
-		handleTestResult(test, &suite);
+		handleTestResult(test, &suite)
 		results.Suites = append(results.Suites, suite)
 
 		if err != nil {
@@ -203,7 +203,7 @@ func (o *testCmdOptions) runTest(cmd *cobra.Command, source string, results *v1a
 	}
 }
 
-func (o *testCmdOptions) runTestGroup(cmd *cobra.Command, source string, results *v1alpha1.TestResults) {
+func (o *runCmdOptions) runTestGroup(cmd *cobra.Command, source string, results *v1alpha1.TestResults) {
 	c, err := o.GetCmdClient()
 	if err != nil {
 		handleTestError("", source, results, err)
@@ -251,7 +251,7 @@ func (o *testCmdOptions) runTestGroup(cmd *cobra.Command, source string, results
 			var test *v1alpha1.Test
 			test, err = o.createAndRunTest(cmd, c, name, runConfig)
 			if test != nil {
-				handleTestResult(test, &suite);
+				handleTestResult(test, &suite)
 				results.Suites = append(results.Suites, suite)
 
 				if err != nil {
@@ -283,7 +283,7 @@ func handleTestResult(test *v1alpha1.Test, suite *v1alpha1.TestSuite) {
 	}
 }
 
-func (o *testCmdOptions) getRunConfig(source string) (*config.RunConfig, error) {
+func (o *runCmdOptions) getRunConfig(source string) (*config.RunConfig, error) {
 	var configFile string
 	var runConfig *config.RunConfig
 
@@ -316,7 +316,7 @@ func (o *testCmdOptions) getRunConfig(source string) (*config.RunConfig, error) 
 	return runConfig, nil
 }
 
-func (o *testCmdOptions) createTempNamespace(runConfig *config.RunConfig, c client.Client) (metav1.Object, error) {
+func (o *runCmdOptions) createTempNamespace(runConfig *config.RunConfig, c client.Client) (metav1.Object, error) {
 	namespaceName := "yaks-" + uuid.New().String()
 	namespace, err := initializeTempNamespace(namespaceName, c, o.Context)
 	if err != nil {
@@ -365,10 +365,10 @@ func (o *testCmdOptions) createTempNamespace(runConfig *config.RunConfig, c clie
 	return namespace, nil
 }
 
-func (o *testCmdOptions) setupOperator(c client.Client, namespace string) error {
+func (o *runCmdOptions) setupOperator(c client.Client, namespace string) error {
 	var cluster v1alpha1.ClusterType
 	if isOpenshift, err := openshift.IsOpenShift(c); err != nil {
-		return err;
+		return err
 	} else if isOpenshift {
 		cluster = v1alpha1.ClusterTypeKubernetes
 	} else {
@@ -387,7 +387,7 @@ func (o *testCmdOptions) setupOperator(c client.Client, namespace string) error 
 	return err
 }
 
-func (o *testCmdOptions) createAndRunTest(cmd *cobra.Command, c client.Client, rawName string, runConfig *config.RunConfig) (*v1alpha1.Test, error) {
+func (o *runCmdOptions) createAndRunTest(cmd *cobra.Command, c client.Client, rawName string, runConfig *config.RunConfig) (*v1alpha1.Test, error) {
 	namespace := runConfig.Config.Namespace.Name
 	fileName := kubernetes.SanitizeFileName(rawName)
 	name := kubernetes.SanitizeName(rawName)
@@ -466,36 +466,36 @@ func (o *testCmdOptions) createAndRunTest(cmd *cobra.Command, c client.Client, r
 	}
 
 	if runConfig.Config.Runtime.Secret != "" {
-		test.Spec.Secret = runConfig.Config.Runtime.Secret;
+		test.Spec.Secret = runConfig.Config.Runtime.Secret
 	}
 
 	if runConfig.Config.Runtime.Selenium.Image != "" {
 		test.Spec.Selenium = v1alpha1.SeleniumSpec{
 			Image: runConfig.Config.Runtime.Selenium.Image,
-		};
+		}
 	}
 
 	switch o.DumpFormat {
-		case "":
-			// continue..
-		case "yaml":
-			data, err := kubernetes.ToYAML(&test)
-			if err != nil {
-				return nil, err
-			}
-			fmt.Print(string(data))
-			return nil, nil
+	case "":
+		// continue..
+	case "yaml":
+		data, err := kubernetes.ToYAML(&test)
+		if err != nil {
+			return nil, err
+		}
+		fmt.Print(string(data))
+		return nil, nil
 
-		case "json":
-			data, err := kubernetes.ToJSON(&test)
-			if err != nil {
-				return nil, err
-			}
-			fmt.Print(string(data))
-			return nil, nil
+	case "json":
+		data, err := kubernetes.ToJSON(&test)
+		if err != nil {
+			return nil, err
+		}
+		fmt.Print(string(data))
+		return nil, nil
 
-		default:
-			return nil, fmt.Errorf("invalid dump output format option '%s', should be one of: yaml|json", o.DumpFormat)
+	default:
+		return nil, fmt.Errorf("invalid dump output format option '%s', should be one of: yaml|json", o.DumpFormat)
 	}
 
 	existed := false
@@ -551,7 +551,7 @@ func (o *testCmdOptions) createAndRunTest(cmd *cobra.Command, c client.Client, r
 		waitTimeout, parseErr := time.ParseDuration(timeout)
 		if parseErr != nil {
 			fmt.Println(fmt.Sprintf("failed to parse test timeout setting - %s", parseErr.Error()))
-			waitTimeout, _ = time.ParseDuration(config.DefaultTimeout);
+			waitTimeout, _ = time.ParseDuration(config.DefaultTimeout)
 		}
 
 		err = kubernetes.WaitCondition(o.Context, c, &test, func(obj interface{}) (bool, error) {
@@ -584,7 +584,7 @@ func (o *testCmdOptions) createAndRunTest(cmd *cobra.Command, c client.Client, r
 	return &test, status.AsError(name)
 }
 
-func (o *testCmdOptions) uploadArtifacts(runConfig *config.RunConfig) error {
+func (o *runCmdOptions) uploadArtifacts(runConfig *config.RunConfig) error {
 	for _, lib := range o.Uploads {
 		additionalDep, err := uploadLocalArtifact(o.RootCmdOptions, resolvePath(runConfig, lib), runConfig.Config.Namespace.Name)
 		if err != nil {
@@ -595,7 +595,7 @@ func (o *testCmdOptions) uploadArtifacts(runConfig *config.RunConfig) error {
 	return nil
 }
 
-func (o *testCmdOptions) setupEnvSettings(test *v1alpha1.Test, runConfig *config.RunConfig) error {
+func (o *runCmdOptions) setupEnvSettings(test *v1alpha1.Test, runConfig *config.RunConfig) error {
 	env := make([]string, 0)
 
 	env = append(env, NamespaceEnv+"="+runConfig.Config.Namespace.Name)
@@ -649,7 +649,7 @@ func (o *testCmdOptions) setupEnvSettings(test *v1alpha1.Test, runConfig *config
 	return nil
 }
 
-func (o *testCmdOptions) newSettings(runConfig *config.RunConfig) (*v1alpha1.SettingsSpec, error) {
+func (o *runCmdOptions) newSettings(runConfig *config.RunConfig) (*v1alpha1.SettingsSpec, error) {
 	if o.Settings != "" {
 		rawName := o.Settings
 		configData, err := o.loadData(resolvePath(runConfig, rawName))
@@ -658,7 +658,7 @@ func (o *testCmdOptions) newSettings(runConfig *config.RunConfig) (*v1alpha1.Set
 			return nil, err
 		}
 
-		settings := v1alpha1.SettingsSpec {
+		settings := v1alpha1.SettingsSpec{
 			Name:    kubernetes.SanitizeFileName(rawName),
 			Content: configData,
 		}
@@ -675,7 +675,7 @@ func (o *testCmdOptions) newSettings(runConfig *config.RunConfig) (*v1alpha1.Set
 			return nil, err
 		}
 
-		settings := v1alpha1.SettingsSpec {
+		settings := v1alpha1.SettingsSpec{
 			Name:    "yaks.settings.yaml",
 			Content: string(configData),
 		}
@@ -686,7 +686,7 @@ func (o *testCmdOptions) newSettings(runConfig *config.RunConfig) (*v1alpha1.Set
 	return nil, nil
 }
 
-func (o *testCmdOptions) findInstance(c client.Client, namespace string) (*v1alpha1.Instance, error) {
+func (o *runCmdOptions) findInstance(c client.Client, namespace string) (*v1alpha1.Instance, error) {
 	yaks := v1alpha1.Instance{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       v1alpha1.InstanceKind,
@@ -706,7 +706,7 @@ func (o *testCmdOptions) findInstance(c client.Client, namespace string) (*v1alp
 	return &yaks, err
 }
 
-func (o *testCmdOptions) listInstances(c client.Client) (v1alpha1.InstanceList, error) {
+func (o *runCmdOptions) listInstances(c client.Client) (v1alpha1.InstanceList, error) {
 	instanceList := v1alpha1.InstanceList{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       v1alpha1.InstanceKind,
@@ -860,7 +860,7 @@ func deleteTempNamespace(ns metav1.Object, c client.Client, context context.Cont
 	fmt.Println(fmt.Sprintf("AutoRemove namespace %s", ns.GetName()))
 }
 
-func (*testCmdOptions) loadData(fileName string) (string, error) {
+func (*runCmdOptions) loadData(fileName string) (string, error) {
 	var content []byte
 	var err error
 


### PR DESCRIPTION
Add commands to YAKS CLI

- Delete tests
- List tests
- Watch logs
- Use "run" as alias for "test" command
- Add `--wait` and `--logs` option to run/test command

Fixes #287 
Fixes #288 
Fixes #290 