### PR TITLE
fix(#293): Fix Knative apiVersion usage

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -363,8 +363,8 @@
           <artifactId>maven-compiler-plugin</artifactId>
           <version>${maven-compiler-plugin.version}</version>
           <configuration>
-            <source>1.8</source>
-            <target>1.8</target>
+            <source>${maven.compiler.source}</source>
+            <target>${maven.compiler.target}</target>
             <compilerArgs>
               <arg>-Xlint:deprecation</arg>
             </compilerArgs>

--- a/java/steps/yaks-knative/src/main/java/org/citrusframework/yaks/knative/KnativeSettings.java
+++ b/java/steps/yaks-knative/src/main/java/org/citrusframework/yaks/knative/KnativeSettings.java
@@ -194,4 +194,13 @@ public class KnativeSettings {
         return Boolean.parseBoolean(System.getProperty(AUTO_REMOVE_RESOURCES_PROPERTY,
                 System.getenv(AUTO_REMOVE_RESOURCES_ENV) != null ? System.getenv(AUTO_REMOVE_RESOURCES_ENV) : AUTO_REMOVE_RESOURCES_DEFAULT));
     }
+
+    public static String getKnativeMessagingGroup() {
+        return "messaging.knative.dev";
+    }
+
+    public static String getKnativeEventingGroup() {
+        return "eventing.knative.dev";
+    }
+
 }

--- a/java/steps/yaks-knative/src/main/java/org/citrusframework/yaks/knative/KnativeSupport.java
+++ b/java/steps/yaks-knative/src/main/java/org/citrusframework/yaks/knative/KnativeSupport.java
@@ -60,4 +60,12 @@ public final class KnativeSupport {
     public static String knativeApiVersion() {
         return KnativeSettings.getApiVersion();
     }
+
+    public static String knativeMessagingGroup() {
+        return KnativeSettings.getKnativeMessagingGroup();
+    }
+
+    public static String knativeEventingGroup() {
+        return KnativeSettings.getKnativeEventingGroup();
+    }
 }

--- a/java/steps/yaks-knative/src/main/java/org/citrusframework/yaks/knative/actions/KnativeAction.java
+++ b/java/steps/yaks-knative/src/main/java/org/citrusframework/yaks/knative/actions/KnativeAction.java
@@ -54,7 +54,7 @@ public interface KnativeAction extends TestAction {
      */
     default String namespace(TestContext context) {
         if (context.getVariables().containsKey(KnativeVariableNames.NAMESPACE.value())) {
-            context.getVariable(KnativeVariableNames.NAMESPACE.value());
+            return context.getVariable(KnativeVariableNames.NAMESPACE.value());
         }
 
         return KnativeSettings.getNamespace();

--- a/java/steps/yaks-knative/src/main/java/org/citrusframework/yaks/knative/actions/eventing/CreateBrokerAction.java
+++ b/java/steps/yaks-knative/src/main/java/org/citrusframework/yaks/knative/actions/eventing/CreateBrokerAction.java
@@ -40,7 +40,7 @@ public class CreateBrokerAction extends AbstractKnativeAction {
     @Override
     public void doExecute(TestContext context) {
         Broker broker = new BrokerBuilder()
-                .withApiVersion(KnativeSupport.knativeApiVersion())
+                .withApiVersion(String.format("%s/%s", KnativeSupport.knativeEventingGroup(), KnativeSupport.knativeApiVersion()))
                 .withNewMetadata()
                     .withNamespace(namespace(context))
                     .withName(context.replaceDynamicContentInString(brokerName))

--- a/java/steps/yaks-knative/src/main/java/org/citrusframework/yaks/knative/actions/eventing/CreateTriggerAction.java
+++ b/java/steps/yaks-knative/src/main/java/org/citrusframework/yaks/knative/actions/eventing/CreateTriggerAction.java
@@ -27,7 +27,6 @@ import io.fabric8.knative.eventing.v1.TriggerSpecBuilder;
 import org.citrusframework.yaks.knative.KnativeSettings;
 import org.citrusframework.yaks.knative.KnativeSupport;
 import org.citrusframework.yaks.knative.actions.AbstractKnativeAction;
-import org.citrusframework.yaks.kubernetes.KubernetesSupport;
 
 /**
  * @author Christoph Deppisch
@@ -59,7 +58,7 @@ public class CreateTriggerAction extends AbstractKnativeAction {
         addFilterOnAttributes(triggerSpec, context);
 
         Trigger trigger = new TriggerBuilder()
-                .withApiVersion(KnativeSupport.knativeApiVersion())
+                .withApiVersion(String.format("%s/%s", KnativeSupport.knativeEventingGroup(), KnativeSupport.knativeApiVersion()))
                 .withNewMetadata()
                     .withNamespace(namespace(context))
                     .withName(context.replaceDynamicContentInString(triggerName))
@@ -85,7 +84,7 @@ public class CreateTriggerAction extends AbstractKnativeAction {
         if (channelName != null) {
             triggerSpec.withNewSubscriber()
                     .withNewRef()
-                        .withApiVersion(KnativeSupport.knativeApiVersion())
+                        .withApiVersion(String.format("%s/%s", KnativeSupport.knativeMessagingGroup(), KnativeSupport.knativeApiVersion()))
                         .withKind("InMemoryChannel")
                         .withName(context.replaceDynamicContentInString(channelName))
                     .endRef()
@@ -97,7 +96,7 @@ public class CreateTriggerAction extends AbstractKnativeAction {
         if (serviceName != null) {
             triggerSpec.withNewSubscriber()
                     .withNewRef()
-                        .withApiVersion(KubernetesSupport.kubernetesApiVersion())
+                        .withApiVersion("v1")
                         .withKind("Service")
                         .withName(context.replaceDynamicContentInString(serviceName))
                     .endRef()

--- a/java/steps/yaks-knative/src/main/java/org/citrusframework/yaks/knative/actions/messaging/CreateChannelAction.java
+++ b/java/steps/yaks-knative/src/main/java/org/citrusframework/yaks/knative/actions/messaging/CreateChannelAction.java
@@ -40,7 +40,7 @@ public class CreateChannelAction extends AbstractKnativeAction {
     @Override
     public void doExecute(TestContext context) {
         Channel channel = new ChannelBuilder()
-            .withApiVersion(KnativeSupport.knativeApiVersion())
+            .withApiVersion(String.format("%s/%s", KnativeSupport.knativeMessagingGroup(), KnativeSupport.knativeApiVersion()))
             .withNewMetadata()
                 .withNamespace(namespace(context))
                 .withName(context.replaceDynamicContentInString(channelName))

--- a/java/steps/yaks-knative/src/main/java/org/citrusframework/yaks/knative/actions/messaging/CreateSubscriptionAction.java
+++ b/java/steps/yaks-knative/src/main/java/org/citrusframework/yaks/knative/actions/messaging/CreateSubscriptionAction.java
@@ -24,7 +24,6 @@ import io.fabric8.kubernetes.api.model.ObjectReferenceBuilder;
 import org.citrusframework.yaks.knative.KnativeSettings;
 import org.citrusframework.yaks.knative.KnativeSupport;
 import org.citrusframework.yaks.knative.actions.AbstractKnativeAction;
-import org.citrusframework.yaks.kubernetes.KubernetesSupport;
 
 /**
  * @author Christoph Deppisch
@@ -46,7 +45,7 @@ public class CreateSubscriptionAction extends AbstractKnativeAction {
     @Override
     public void doExecute(TestContext context) {
         Subscription subscription = new SubscriptionBuilder()
-                .withApiVersion(KnativeSupport.knativeApiVersion())
+                .withApiVersion(String.format("%s/%s", KnativeSupport.knativeMessagingGroup(), KnativeSupport.knativeApiVersion()))
                 .withNewMetadata()
                     .withNamespace(namespace(context))
                     .withName(context.replaceDynamicContentInString(subscriptionName))
@@ -54,13 +53,13 @@ public class CreateSubscriptionAction extends AbstractKnativeAction {
                 .endMetadata()
                 .withNewSpec()
                     .withChannel(new ObjectReferenceBuilder()
-                            .withApiVersion(String.format("messaging.knative.dev/%s", KnativeSupport.knativeApiVersion()))
+                            .withApiVersion(String.format("%s/%s", KnativeSupport.knativeMessagingGroup(), KnativeSupport.knativeApiVersion()))
                             .withKind("InMemoryChannel")
                             .withName(context.replaceDynamicContentInString(channelName))
                             .build())
                     .withNewSubscriber()
                         .withNewRef()
-                            .withApiVersion(KubernetesSupport.kubernetesApiVersion())
+                            .withApiVersion("v1")
                             .withKind("Service")
                             .withName(context.replaceDynamicContentInString(serviceName))
                         .endRef()

--- a/java/steps/yaks-knative/src/test/resources/org/citrusframework/yaks/knative/knative.eventing.feature
+++ b/java/steps/yaks-knative/src/test/resources/org/citrusframework/yaks/knative/knative.eventing.feature
@@ -11,11 +11,13 @@ Feature: Knative eventing
     Then Knative broker my-broker is running
 
   Scenario: Create service and trigger
+    Given Knative namespace trigger
     Given create Knative event consumer service hello-service with target port 8080
     Given create Knative trigger hello-trigger on service hello-service
     Then verify Knative trigger hello-trigger exists
 
   Scenario: Create trigger with filter
+    Given Knative namespace trigger-with-filter
     Given create Knative trigger filtered-trigger on service hello-service with filter on attributes
       | app    | yaks |
       | source | testing |

--- a/java/steps/yaks-kubernetes/src/main/java/org/citrusframework/yaks/kubernetes/actions/KubernetesAction.java
+++ b/java/steps/yaks-kubernetes/src/main/java/org/citrusframework/yaks/kubernetes/actions/KubernetesAction.java
@@ -47,7 +47,7 @@ public interface KubernetesAction extends TestAction {
      */
     default String namespace(TestContext context) {
         if (context.getVariables().containsKey(KubernetesVariableNames.NAMESPACE.value())) {
-            context.getVariable(KubernetesVariableNames.NAMESPACE.value());
+            return context.getVariable(KubernetesVariableNames.NAMESPACE.value());
         }
 
         return KubernetesSettings.getNamespace();

--- a/pkg/util/knative/apis.go
+++ b/pkg/util/knative/apis.go
@@ -110,14 +110,6 @@ var (
 			},
 			Resource: "brokers",
 		},
-		{
-			GroupVersionKind: schema.GroupVersionKind{
-				Kind:    "Broker",
-				Group:   "eventing.knative.dev",
-				Version: "v1beta1",
-			},
-			Resource: "brokers",
-		},
 	}
 )
 


### PR DESCRIPTION
- Must use proper Knative group (eventing.knative.dev, messaging.knative.dev) when specifying api versions on resources
- Fix required Knative kinds. Do not require v1beta1 to install Knative roles
- Fix custom namespace setting in Kubernetes and Knative steps

Fixes #293 