### PR TITLE
fix(#257): Fix additional roles and role bindings on the YAKS operator

### DIFF
--- a/examples/custom-resources/README.adoc
+++ b/examples/custom-resources/README.adoc
@@ -35,6 +35,54 @@ spec:
   - name: v1alpha1
     served: true
     storage: true
+    schema:
+      openAPIV3Schema:
+        description: Foo resource schema
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of Test
+            properties:
+              message:
+                type: string
+            required:
+              - message
+            type: object
+          status:
+            description: Status defines the observed state of Foo
+            properties:
+              conditions:
+                items:
+                  description: Condition describes the state of a resource at a certain point.
+                  properties:
+                    message:
+                      description: A human readable message indicating details about the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition.
+                      type: string
+                  required:
+                    - status
+                    - type
+                  type: object
+                type: array
+              version:
+                type: string
+            type: object
+        type: object
     subresources:
       status: {}
 ----
@@ -191,3 +239,30 @@ Scenario: Create foo
 The step above create the custom resource in the current test namespace.
 The YAKS operator has applied the proper roles and permissions to the `yaks-viewer` service account.
 So you may not run into permission errors when creating this custom resource.
+
+== Usage with temporary namespaces
+
+IMPORTANT: When using temporary namespaces in combination with a non-global YAKS operator, you need to add the roles explicitly
+in the runtime configuration in `yaks-config.yaml`. This is not required when using a global YAKS operator.
+
+In case you want to make use of temporary namespaces you need to add the roles to the runtime configuration of the test.
+This is because the operator for the temporary namespace will not be able to automatically apply the additional operator
+roles.
+
+Please add the roles to the `yaks-config.yaml` as follows.
+
+.yaks-config.yaml
+[source,yaml]
+----
+config:
+  operator:
+    roles:
+      - role-foo.yaml
+      - role-binding-foo.yaml
+  namespace:
+    temporary: true
+----
+
+This makes sure that the yaks command line tool installs the roles on the temporary namespace before the test is run.
+
+IMPORTANT: The approach requires the YAKS command line tool user to have sufficient permissions to manage roles on the cluster.

--- a/java/docs/steps-kubernetes.adoc
+++ b/java/docs/steps-kubernetes.adoc
@@ -356,7 +356,7 @@ Given load Kubernetes custom resource broker.yaml in brokers.eventing.knative.de
 Once again the step needs to have the CRD type and the YAML specification as a file resource.
 
 IMPORTANT: You need to make sure that the YAKS runtime has proper permissions to manage the custom resource.
-The proper roles and role bindings need to apply to the YAKS operagtor service account `yaks-operator`.
+The proper roles and role bindings need to apply to the YAKS operator service account `yaks-operator`.
 
 Prior to using the custom resource in a YAKS test you need to grant role permissions to the YAKS runtime.
 Otherwise, the test is not allowed to create the custom resource due to security constraints on the cluster.
@@ -396,6 +396,54 @@ spec:
   - name: v1alpha1
     served: true
     storage: true
+    schema:
+      openAPIV3Schema:
+        description: Foo resource schema
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of Test
+            properties:
+              message:
+                type: string
+            required:
+              - message
+            type: object
+          status:
+            description: Status defines the observed state of Foo
+            properties:
+              conditions:
+                items:
+                  description: Condition describes the state of a resource at a certain point.
+                  properties:
+                    message:
+                      description: A human readable message indicating details about the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition.
+                      type: string
+                  required:
+                    - status
+                    - type
+                  type: object
+                type: array
+              version:
+                type: string
+            type: object
+        type: object
     subresources:
       status: {}
 ----
@@ -462,7 +510,7 @@ yaks role –add role-binding-foo.yaml
 ----
 
 The commands above create the role and role bindings on the `yaks-operator` service account.
-The command automatically coveres all available operator instances on the cluster.
+The command automatically covers all available operator instances on the cluster.
 Also, the command will automatically convert the role to a cluster role when there is a global operator on the cluster.
 
 IMPORTANT: This role setup must be done by a cluster administrator.
@@ -472,6 +520,31 @@ This makes sure that the YAKS operator adds the permissions also to the `yaks-vi
 This is done automatically when the operator starts a new test.
 
 As a naming convention the roles and role bindings targeting on the YAKS operator use the `yaks-operator-` name prefix.
+
+IMPORTANT: When using temporary namespaces in combination with a non-global YAKS operator, you need to add the roles explicitly
+in the runtime configuration in `yaks-config.yaml`. This is not required when using a global YAKS operator.
+
+In case you want to make use of temporary namespaces you need to add the roles to the runtime configuration of the test.
+This is because the operator for the temporary namespace will not be able to automatically apply the additional operator
+roles.
+
+Please add the roles to the `yaks-config.yaml` as follows.
+
+.yaks-config.yaml
+[source,yaml]
+----
+config:
+  operator:
+    roles:
+      - role-foo.yaml
+      - role-binding-foo.yaml
+  namespace:
+    temporary: true
+----
+
+This makes sure that the yaks command line tool installs the roles on the temporary namespace before the test is run.
+
+IMPORTANT: The approach requires the YAKS command line tool user to have sufficient permissions to manage roles on the cluster.
 
 In case you need to delete a custom resource from Kubernetes the user has to provide a minimal
 YAML specification that identifies the resource.

--- a/pkg/apis/yaks/v1alpha1/instance_types_support.go
+++ b/pkg/apis/yaks/v1alpha1/instance_types_support.go
@@ -17,10 +17,37 @@ limitations under the License.
 
 package v1alpha1
 
+import (
+	"context"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// GetInstance return the YAKS operator instance in given namespace
+func GetInstance(ctx context.Context, client ctrl.Client, namespace string) (*Instance, error) {
+	instance := Instance{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       InstanceKind,
+			APIVersion: SchemeGroupVersion.String(),
+		},
+	}
+
+	key := ctrl.ObjectKey{
+		Namespace: namespace,
+		Name:      "yaks",
+	}
+
+	if err := client.Get(ctx, key, &instance); err != nil {
+		return nil, err
+	}
+
+	return &instance, nil
+}
+
 // IsGlobal returns true if the given instance is configured to watch all namespaces
 func IsGlobal(instance *Instance) bool {
 	if instance == nil {
-		return false;
+		return false
 	}
 
 	return instance.Spec.Operator.Global

--- a/pkg/cmd/config/config.go
+++ b/pkg/cmd/config/config.go
@@ -18,121 +18,122 @@ limitations under the License.
 package config
 
 import (
-    "io/ioutil"
-    "os"
+	"io/ioutil"
+	"os"
 
-    "gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v2"
 )
 
 const (
-    DefaultTimeout = "30m"
+	DefaultTimeout = "30m"
 )
 
 type RunConfig struct {
-    BaseDir string       `yaml:"baseDir"`
-    Config  Config       `yaml:"config"`
-    Pre     []StepConfig `yaml:"pre"`
-    Post    []StepConfig `yaml:"post"`
+	BaseDir string       `yaml:"baseDir"`
+	Config  Config       `yaml:"config"`
+	Pre     []StepConfig `yaml:"pre"`
+	Post    []StepConfig `yaml:"post"`
 }
 
 type Config struct {
-    Recursive bool            `yaml:"recursive"`
-    Timeout   string          `yaml:"timeout"`
-    Namespace NamespaceConfig `yaml:"namespace"`
-    Operator  OperatorConfig  `yaml:"operator"`
-    Runtime   RuntimeConfig   `yaml:"runtime"`
+	Recursive bool            `yaml:"recursive"`
+	Timeout   string          `yaml:"timeout"`
+	Namespace NamespaceConfig `yaml:"namespace"`
+	Operator  OperatorConfig  `yaml:"operator"`
+	Runtime   RuntimeConfig   `yaml:"runtime"`
 }
 
 type StepConfig struct {
-    Run     string `yaml:"run"`
-    Script  string `yaml:"script"`
-    Name    string `yaml:"name"`
-    Timeout string `yaml:"timeout"`
+	Run     string `yaml:"run"`
+	Script  string `yaml:"script"`
+	Name    string `yaml:"name"`
+	Timeout string `yaml:"timeout"`
 }
 
 type RuntimeConfig struct {
-    Cucumber  CucumberConfig `yaml:"cucumber"`
-    Selenium  SeleniumConfig `yaml:"selenium"`
-    Resources []string 	     `yaml:"resources"`
-    Settings  SettingsConfig `yaml:"settings"`
-    Env 	  []EnvConfig 	 `yaml:"env"`
-    Secret    string 		 `yaml:"secret"`
+	Cucumber  CucumberConfig `yaml:"cucumber"`
+	Selenium  SeleniumConfig `yaml:"selenium"`
+	Resources []string       `yaml:"resources"`
+	Settings  SettingsConfig `yaml:"settings"`
+	Env       []EnvConfig    `yaml:"env"`
+	Secret    string         `yaml:"secret"`
 }
 
 type CucumberConfig struct {
-    Tags    []string `yaml:"tags"`
-    Glue    []string `yaml:"glue"`
-    Options string   `yaml:"options"`
+	Tags    []string `yaml:"tags"`
+	Glue    []string `yaml:"glue"`
+	Options string   `yaml:"options"`
 }
 
 type SeleniumConfig struct {
-    Image           string `yaml:"image"`
+	Image string `yaml:"image"`
 }
 
 type EnvConfig struct {
-    Name  string `yaml:"name"`
-    Value string `yaml:"value"`
+	Name  string `yaml:"name"`
+	Value string `yaml:"value"`
 }
 
 type SettingsConfig struct {
-    Repositories []RepositoryConfig `yaml:"repositories"`
-    Dependencies []DependencyConfig `yaml:"dependencies"`
-    Loggers 	 []LoggerConfig     `yaml:"loggers"`
+	Repositories []RepositoryConfig `yaml:"repositories"`
+	Dependencies []DependencyConfig `yaml:"dependencies"`
+	Loggers      []LoggerConfig     `yaml:"loggers"`
 }
 
 type RepositoryConfig struct {
-    Id        string `yaml:"id"`
-    Name      string `yaml:"name,omitempty"`
-    Url       string `yaml:"url"`
-    Layout    string `yaml:"layout,omitempty"`
-    Releases  PolicyConfig `yaml:"releases,omitempty"`
-    Snapshots PolicyConfig `yaml:"snapshots,omitempty"`
+	Id        string       `yaml:"id"`
+	Name      string       `yaml:"name,omitempty"`
+	Url       string       `yaml:"url"`
+	Layout    string       `yaml:"layout,omitempty"`
+	Releases  PolicyConfig `yaml:"releases,omitempty"`
+	Snapshots PolicyConfig `yaml:"snapshots,omitempty"`
 }
 
 type PolicyConfig struct {
-    Enabled      string `yaml:"enabled,omitempty"`
-    UpdatePolicy string `yaml:"updatePolicy,omitempty"`
+	Enabled      string `yaml:"enabled,omitempty"`
+	UpdatePolicy string `yaml:"updatePolicy,omitempty"`
 }
 
 type DependencyConfig struct {
-    GroupId    string `yaml:"groupId"`
-    ArtifactId string `yaml:"artifactId"`
-    Version    string `yaml:"version"`
+	GroupId    string `yaml:"groupId"`
+	ArtifactId string `yaml:"artifactId"`
+	Version    string `yaml:"version"`
 }
 
 type LoggerConfig struct {
-    Name  string `yaml:"name"`
-    Level string `yaml:"level"`
+	Name  string `yaml:"name"`
+	Level string `yaml:"level"`
 }
 
 type NamespaceConfig struct {
-    Name       string `yaml:"name"`
-    Temporary  bool   `yaml:"temporary"`
-    AutoRemove bool   `yaml:"autoRemove"`
+	Name       string `yaml:"name"`
+	Temporary  bool   `yaml:"temporary"`
+	AutoRemove bool   `yaml:"autoRemove"`
 }
 
 type OperatorConfig struct {
-    Namespace string `yaml:"namespace"`
+	Namespace string   `yaml:"namespace"`
+	Roles     []string `yaml:"roles"`
 }
 
 func NewWithDefaults() *RunConfig {
-    ns := NamespaceConfig {
-        AutoRemove: true,
-        Temporary:  false,
-    }
+	ns := NamespaceConfig{
+		AutoRemove: true,
+		Temporary:  false,
+	}
 
-    var config = Config {Recursive: true, Namespace: ns, Timeout: DefaultTimeout}
-    return &RunConfig {Config: config, BaseDir: ""}
+	var config = Config{Recursive: true, Namespace: ns, Timeout: DefaultTimeout}
+	return &RunConfig{Config: config, BaseDir: ""}
 }
 
 func LoadConfig(file string) (*RunConfig, error) {
-    config := NewWithDefaults()
-    data, err := ioutil.ReadFile(file)
-    if err != nil && os.IsNotExist(err) {
-        return config, nil
-    }
-    if err = yaml.Unmarshal(data, config); err != nil {
-        return nil, err
-    }
-    return config, nil
+	config := NewWithDefaults()
+	data, err := ioutil.ReadFile(file)
+	if err != nil && os.IsNotExist(err) {
+		return config, nil
+	}
+	if err = yaml.Unmarshal(data, config); err != nil {
+		return nil, err
+	}
+	return config, nil
 }

--- a/pkg/install/operator.go
+++ b/pkg/install/operator.go
@@ -105,7 +105,7 @@ func OperatorOrCollect(ctx context.Context, c client.Client, cfg OperatorConfigu
 	return nil
 }
 
-func customizer(cfg OperatorConfiguration) func(o ctrl.Object) ctrl.Object {
+func customizer(cfg OperatorConfiguration) ResourceCustomizer {
 	return func(o ctrl.Object) ctrl.Object {
 		if cfg.CustomImage != "" {
 			if d, ok := o.(*appsv1.Deployment); ok {


### PR DESCRIPTION
- Make sure that the approach is working with both global and non-global YAKS operators
- Add explicit role configuration on yaks-config.yaml in order to support temporary namespaces in combination with non-global operator