### PR TITLE
Fix verify resource status method

### DIFF
--- a/java/steps/yaks-kubernetes/src/main/java/org/citrusframework/yaks/kubernetes/actions/VerifyCustomResourceAction.java
+++ b/java/steps/yaks-kubernetes/src/main/java/org/citrusframework/yaks/kubernetes/actions/VerifyCustomResourceAction.java
@@ -176,7 +176,7 @@ public class VerifyCustomResourceAction extends AbstractKubernetesAction {
 
         return conditions.stream()
                 .anyMatch(propertyMap -> propertyMap.getOrDefault("type", "").equals(condition)
-                        && Optional.ofNullable(propertyMap.get("status")).map(Boolean.class::cast).orElse(false));
+                        && Optional.ofNullable(propertyMap.get("status")).map(b -> Boolean.valueOf(b.toString())).orElse(false));
     }
 
     /**


### PR DESCRIPTION
Fixes
```
ava.lang.String,java.lang.String)
  Given Kubernetes custom resource event-streaming-kafka-cluster in kafkas.kafka.strimzi.io/v1beta1 is ready # org.citrusframework.yaks.kubernetes.KubernetesSteps.resourceShouldBeReady(java.lang.String,java.lang.String)
      com.consol.citrus.exceptions.TestCaseFailedException: Cannot cast java.lang.String to java.lang.Boolean
        at com.consol.citrus.DefaultTestCase.executeAction(DefaultTestCase.java:144)
        at com.consol.citrus.DefaultTestCaseRunner.run(DefaultTestCaseRunner.java:125)
        at org.citrusframework.yaks.kubernetes.KubernetesSteps.resourceShouldMatchCondition(KubernetesSteps.java:299)
        at org.citrusframework.yaks.kubernetes.KubernetesSteps.resourceShouldBeReady(KubernetesSteps.java:311)
        at ✽.Kubernetes custom resource event-streaming-kafka-cluster in kafkas.kafka.strimzi.io/v1beta1 is ready(classpath:org/citrusframework/yaks/CrimeBridge.feature:18)
Caused by: java.lang.ClassCastException: Cannot cast java.lang.String to java.lang.Boolean
        at java.lang.Class.cast(Unknown Source)
        at java.util.Optional.map(Unknown Source)
        at org.citrusframework.yaks.kubernetes.actions.VerifyCustomResourceAction.lambda$verifyResourceStatus$0(VerifyCustomResourceAction.java:179)
        at java.util.stream.MatchOps$1MatchSink.accept(Unknown Source)
        at java.util.ArrayList$ArrayListSpliterator.tryAdvance(Unknown Source)
        at java.util.stream.ReferencePipeline.forEachWithCancel(Unknown Source)
        at java.util.stream.AbstractPipeline.copyIntoWithCancel(Unknown Source)
        at java.util.stream.AbstractPipeline.copyInto(Unknown Source)
        at java.util.stream.AbstractPipeline.wrapAndCopyInto(Unknown Source)
        at java.util.stream.MatchOps$MatchOp.evaluateSequential(Unknown Source)
        at java.util.stream.MatchOps$MatchOp.evaluateSequential(Unknown Source)
        at java.util.stream.AbstractPipeline.evaluate(Unknown Source)
        at java.util.stream.ReferencePipeline.anyMatch(Unknown Source)
        at org.citrusframework.yaks.kubernetes.actions.VerifyCustomResourceAction.verifyResourceStatus(VerifyCustomResourceAction.java:178)
        at org.citrusframework.yaks.kubernetes.actions.VerifyCustomResourceAction.getResource(VerifyCustomResourceAction.java:128)
        at org.citrusframework.yaks.kubernetes.actions.VerifyCustomResourceAction.verifyResource(VerifyCustomResourceAction.java:93)
```