### PR TITLE
Add Jackson BOM to align all Jackson sub libraries

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -257,21 +257,13 @@
         <version>${camel.version}</version>
       </dependency>
 
+      <!-- Import full jackson bom to avoid lib mis-alignment -->
       <dependency>
-        <groupId>com.fasterxml.jackson.core</groupId>
-        <artifactId>jackson-core</artifactId>
+        <groupId>com.fasterxml.jackson</groupId>
+        <artifactId>jackson-bom</artifactId>
         <version>${jackson.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.fasterxml.jackson.core</groupId>
-        <artifactId>jackson-databind</artifactId>
-        <version>${jackson.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>com.fasterxml.jackson.module</groupId>
-        <artifactId>jackson-module-jsonSchema</artifactId>
-        <version>${jackson.version}</version>
+        <scope>import</scope>
+        <type>pom</type>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
This to try fixing errors with missing Jackson classes when executing tests.