### PR TITLE
fix(#322): Fix yaks tar.gz changes the uid/gid of cwd

### DIFF
--- a/script/cross_compile.sh
+++ b/script/cross_compile.sh
@@ -16,7 +16,7 @@
 # limitations under the License.
 
 location=$(dirname $0)
-working_dir=$location/../
+working_dir=$(realpath ${location}/../)
 build_dir=$(realpath ${working_dir}/xtmp)
 
 if [ "$#" -ne 2 ]; then
@@ -28,6 +28,8 @@ version="$1"
 build_flags="$2"
 
 source "$location/util/go_funcs"
+
+cd $working_dir
 
 cross_compile "$working_dir" yaks-${version}-linux-64bit "$build_dir" linux amd64 "$build_flags"
 cross_compile "$working_dir" yaks-${version}-mac-64bit "$build_dir" darwin amd64 "$build_flags"

--- a/script/util/go_funcs
+++ b/script/util/go_funcs
@@ -48,7 +48,7 @@ cross_compile () {
 	cp ${working_dir}/LICENSE ${target_dir}/
 	cp ${working_dir}/NOTICE ${target_dir}/
 
-	pushd . && cd ${target_dir} && tar -zcvf ${working_dir}/${label}.tar.gz . && popd
+	pushd . && cd ${target_dir} && tar -zcvf ${working_dir}/${label}.tar.gz $(ls -A) && popd
 
 	rm -rf ${build_dir}
 }


### PR DESCRIPTION
Excluding "." from the tarball during cross compile

Fixes #322 