### PR TITLE
fix(#368): Add step to explicitly set Camel K namespace

### DIFF
--- a/java/steps/yaks-camel-k/src/main/java/org/citrusframework/yaks/camelk/CamelKSteps.java
+++ b/java/steps/yaks-camel-k/src/main/java/org/citrusframework/yaks/camelk/CamelKSteps.java
@@ -41,6 +41,7 @@ import org.citrusframework.yaks.kubernetes.KubernetesSupport;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.Resource;
 
+import static com.consol.citrus.actions.CreateVariablesAction.Builder.createVariable;
 import static com.consol.citrus.container.Assert.Builder.assertException;
 import static com.consol.citrus.container.FinallySequence.Builder.doFinally;
 import static org.citrusframework.yaks.camelk.actions.CamelKActionBuilder.camelk;
@@ -98,6 +99,12 @@ public class CamelKSteps {
     public void configureResourcePolling(Map<String, Object> configuration) {
         maxAttempts = Integer.parseInt(configuration.getOrDefault("maxAttempts", maxAttempts).toString());
         delayBetweenAttempts = Long.parseLong(configuration.getOrDefault("delayBetweenAttempts", delayBetweenAttempts).toString());
+    }
+
+    @Given("^Camel-K namespace ([^\\s]+)$")
+    public void setNamespace(String namespace) {
+        // update the test variable that points to the namespace
+        runner.run(createVariable(VariableNames.CAMEL_K_NAMESPACE.value(), namespace));
     }
 
 	@Given("^Camel-K integration property file ([^\\s]+)$")

--- a/java/steps/yaks-camel-k/src/main/java/org/citrusframework/yaks/camelk/KameletSteps.java
+++ b/java/steps/yaks-camel-k/src/main/java/org/citrusframework/yaks/camelk/KameletSteps.java
@@ -41,6 +41,7 @@ import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.Resource;
 import org.springframework.util.StringUtils;
 
+import static com.consol.citrus.actions.CreateVariablesAction.Builder.createVariable;
 import static com.consol.citrus.container.FinallySequence.Builder.doFinally;
 import static org.citrusframework.yaks.camelk.actions.CamelKActionBuilder.camelk;
 
@@ -66,6 +67,8 @@ public class KameletSteps {
 
     private Map<String, Object> sourceProperties;
     private Map<String, Object> sinkProperties;
+
+    private String namespace = CamelKSettings.getNamespace();
 
     private boolean autoRemoveResources = CamelKSettings.isAutoRemoveResources();
     private boolean supportVariablesInSources = CamelKSettings.isSupportVariablesInSources();
@@ -98,6 +101,14 @@ public class KameletSteps {
     @Given("^Enable variable support in Kamelet sources$")
     public void enableVariableSupport() {
         supportVariablesInSources = true;
+    }
+
+    @Given("^Kamelet namespace ([^\\s]+)$")
+    public void setNamespace(String namespace) {
+        this.namespace = namespace;
+
+        // update the test variable that points to the namespace
+        runner.run(createVariable(VariableNames.KAMELET_NAMESPACE.value(), namespace));
     }
 
     @Given("^Kamelet type (in|out|error)(?:=| is )\"(.+)\"$")
@@ -158,7 +169,7 @@ public class KameletSteps {
     @Given("^bind Kamelet ([a-z0-9-]+) to uri ([^\\s]+)$")
     public void bindKameletToUri(String kameletName, String uri) {
         KameletBindingSpec.Endpoint.ObjectReference sourceRef =
-                new KameletBindingSpec.Endpoint.ObjectReference(CamelKSupport.CAMELK_CRD_GROUP + "/" + CamelKSettings.getKameletApiVersion(), "Kamelet", CamelKSettings.getNamespace(), kameletName);
+                new KameletBindingSpec.Endpoint.ObjectReference(CamelKSupport.CAMELK_CRD_GROUP + "/" + CamelKSettings.getKameletApiVersion(), "Kamelet", namespace, kameletName);
         source = new KameletBindingSpec.Endpoint(sourceRef);
 
         sink = new KameletBindingSpec.Endpoint(uri);
@@ -167,7 +178,7 @@ public class KameletSteps {
     @Given("^bind Kamelet ([a-z0-9-]+) to Kafka topic ([^\\s]+)$")
     public void bindKameletToKafka(String kameletName, String topic) {
         KameletBindingSpec.Endpoint.ObjectReference sourceRef =
-                new KameletBindingSpec.Endpoint.ObjectReference(CamelKSupport.CAMELK_CRD_GROUP + "/" + CamelKSettings.getKameletApiVersion(), "Kamelet", CamelKSettings.getNamespace(), kameletName);
+                new KameletBindingSpec.Endpoint.ObjectReference(CamelKSupport.CAMELK_CRD_GROUP + "/" + CamelKSettings.getKameletApiVersion(), "Kamelet", namespace, kameletName);
         source = new KameletBindingSpec.Endpoint(sourceRef);
 
         KameletBindingSpec.Endpoint.ObjectReference sinkRef =
@@ -183,7 +194,7 @@ public class KameletSteps {
     @Given("^bind Kamelet ([a-z0-9-]+) to Knative channel ([^\\s]+) of kind ([^\\s]+)$")
     public void bindKameletToKnativeChannel(String kameletName, String channel, String channelKind) {
         KameletBindingSpec.Endpoint.ObjectReference sourceRef =
-                new KameletBindingSpec.Endpoint.ObjectReference(CamelKSupport.CAMELK_CRD_GROUP + "/" + CamelKSettings.getKameletApiVersion(), "Kamelet", CamelKSettings.getNamespace(), kameletName);
+                new KameletBindingSpec.Endpoint.ObjectReference(CamelKSupport.CAMELK_CRD_GROUP + "/" + CamelKSettings.getKameletApiVersion(), "Kamelet", namespace, kameletName);
         source = new KameletBindingSpec.Endpoint(sourceRef);
 
         KameletBindingSpec.Endpoint.ObjectReference sinkRef =

--- a/java/steps/yaks-camel-k/src/main/java/org/citrusframework/yaks/camelk/VariableNames.java
+++ b/java/steps/yaks-camel-k/src/main/java/org/citrusframework/yaks/camelk/VariableNames.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.yaks.camelk;
+
+/**
+ * @author Christoph Deppisch
+ */
+public enum VariableNames {
+
+    CAMEL_K_NAMESPACE("CAMEL_K_NAMESPACE"),
+    KAMELET_NAMESPACE("KAMELET_NAMESPACE");
+
+    private final String variableName;
+
+    VariableNames(String variableName) {
+        this.variableName = variableName;
+    }
+
+    public String value() {
+        return variableName;
+    }
+
+    @Override
+    public String toString() {
+        return variableName;
+    }
+}

--- a/java/steps/yaks-camel-k/src/main/java/org/citrusframework/yaks/camelk/actions/CamelKAction.java
+++ b/java/steps/yaks-camel-k/src/main/java/org/citrusframework/yaks/camelk/actions/CamelKAction.java
@@ -18,7 +18,10 @@
 package org.citrusframework.yaks.camelk.actions;
 
 import com.consol.citrus.TestAction;
+import com.consol.citrus.context.TestContext;
 import io.fabric8.kubernetes.client.KubernetesClient;
+import org.citrusframework.yaks.camelk.VariableNames;
+import org.citrusframework.yaks.kubernetes.KubernetesSettings;
 
 /**
  * Base action provides access to Knative properties such as broker name. These properties are read from
@@ -34,5 +37,20 @@ public interface CamelKAction extends TestAction {
      * @return
      */
     KubernetesClient getKubernetesClient();
+
+    /**
+     * Resolves namespace name from given test context using the stored test variable.
+     * Fallback to the namespace given in Kubernetes environment settings when no test variable is present.
+     *
+     * @param context
+     * @return
+     */
+    default String namespace(TestContext context) {
+        if (context.getVariables().containsKey(VariableNames.CAMEL_K_NAMESPACE.value())) {
+            return context.getVariable(VariableNames.CAMEL_K_NAMESPACE.value());
+        }
+
+        return KubernetesSettings.getNamespace();
+    }
 }
 

--- a/java/steps/yaks-camel-k/src/main/java/org/citrusframework/yaks/camelk/actions/integration/CreateIntegrationAction.java
+++ b/java/steps/yaks-camel-k/src/main/java/org/citrusframework/yaks/camelk/actions/integration/CreateIntegrationAction.java
@@ -103,7 +103,7 @@ public class CreateIntegrationAction extends AbstractCamelKAction {
         final Integration i = integrationBuilder.build();
         CustomResourceDefinitionContext ctx = CamelKSupport.integrationCRDContext(CamelKSettings.getApiVersion());
         getKubernetesClient().customResources(ctx, Integration.class, IntegrationList.class)
-                .inNamespace(CamelKSettings.getNamespace())
+                .inNamespace(namespace(context))
                 .createOrReplace(i);
 
         LOG.info(String.format("Successfully created Camel-K integration '%s'", i.getMetadata().getName()));

--- a/java/steps/yaks-camel-k/src/main/java/org/citrusframework/yaks/camelk/actions/integration/DeleteIntegrationAction.java
+++ b/java/steps/yaks-camel-k/src/main/java/org/citrusframework/yaks/camelk/actions/integration/DeleteIntegrationAction.java
@@ -42,7 +42,7 @@ public class DeleteIntegrationAction extends AbstractCamelKAction {
     public void doExecute(TestContext context) {
         CustomResourceDefinitionContext ctx = CamelKSupport.integrationCRDContext(CamelKSettings.getApiVersion());
         getKubernetesClient().customResources(ctx, Integration.class, IntegrationList.class)
-                .inNamespace(CamelKSettings.getNamespace())
+                .inNamespace(namespace(context))
                 .withName(integrationName)
                 .delete();
     }

--- a/java/steps/yaks-camel-k/src/main/java/org/citrusframework/yaks/camelk/actions/kamelet/AbstractKameletAction.java
+++ b/java/steps/yaks-camel-k/src/main/java/org/citrusframework/yaks/camelk/actions/kamelet/AbstractKameletAction.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.yaks.camelk.actions.kamelet;
+
+import com.consol.citrus.context.TestContext;
+import org.citrusframework.yaks.camelk.VariableNames;
+import org.citrusframework.yaks.camelk.actions.AbstractCamelKAction;
+
+/**
+ * @author Christoph Deppisch
+ */
+public abstract class AbstractKameletAction extends AbstractCamelKAction {
+
+    public AbstractKameletAction(String name, Builder<?, ?> builder) {
+        super(name, builder);
+    }
+
+    @Override
+    public String namespace(TestContext context) {
+        if (context.getVariables().containsKey(VariableNames.KAMELET_NAMESPACE.value())) {
+            return context.getVariable(VariableNames.KAMELET_NAMESPACE.value());
+        }
+
+        return super.namespace(context);
+    }
+}

--- a/java/steps/yaks-camel-k/src/main/java/org/citrusframework/yaks/camelk/actions/kamelet/CreateKameletAction.java
+++ b/java/steps/yaks-camel-k/src/main/java/org/citrusframework/yaks/camelk/actions/kamelet/CreateKameletAction.java
@@ -31,7 +31,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import io.fabric8.kubernetes.client.dsl.base.CustomResourceDefinitionContext;
 import org.citrusframework.yaks.camelk.CamelKSettings;
 import org.citrusframework.yaks.camelk.CamelKSupport;
-import org.citrusframework.yaks.camelk.actions.AbstractCamelKAction;
 import org.citrusframework.yaks.camelk.model.Kamelet;
 import org.citrusframework.yaks.camelk.model.KameletList;
 import org.citrusframework.yaks.camelk.model.KameletSpec;
@@ -45,7 +44,7 @@ import org.springframework.util.StringUtils;
  *
  * @author Christoph Deppisch
  */
-public class CreateKameletAction extends AbstractCamelKAction {
+public class CreateKameletAction extends AbstractKameletAction {
 
     private final String name;
     private final String flow;
@@ -138,7 +137,7 @@ public class CreateKameletAction extends AbstractCamelKAction {
 
         CustomResourceDefinitionContext ctx = CamelKSupport.kameletCRDContext(CamelKSettings.getKameletApiVersion());
         getKubernetesClient().customResources(ctx, Kamelet.class, KameletList.class)
-                .inNamespace(CamelKSettings.getNamespace())
+                .inNamespace(namespace(context))
                 .createOrReplace(kamelet);
 
         LOG.info(String.format("Successfully created Kamelet '%s'", kamelet.getMetadata().getName()));
@@ -147,7 +146,7 @@ public class CreateKameletAction extends AbstractCamelKAction {
     /**
      * Action builder.
      */
-    public static final class Builder extends AbstractCamelKAction.Builder<CreateKameletAction, Builder> {
+    public static final class Builder extends AbstractKameletAction.Builder<CreateKameletAction, Builder> {
 
         private String name;
         private String flow;

--- a/java/steps/yaks-camel-k/src/main/java/org/citrusframework/yaks/camelk/actions/kamelet/CreateKameletBindingAction.java
+++ b/java/steps/yaks-camel-k/src/main/java/org/citrusframework/yaks/camelk/actions/kamelet/CreateKameletBindingAction.java
@@ -27,7 +27,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import io.fabric8.kubernetes.client.dsl.base.CustomResourceDefinitionContext;
 import org.citrusframework.yaks.camelk.CamelKSettings;
 import org.citrusframework.yaks.camelk.CamelKSupport;
-import org.citrusframework.yaks.camelk.actions.AbstractCamelKAction;
 import org.citrusframework.yaks.camelk.model.Integration;
 import org.citrusframework.yaks.camelk.model.KameletBinding;
 import org.citrusframework.yaks.camelk.model.KameletBindingList;
@@ -41,7 +40,7 @@ import org.springframework.core.io.Resource;
  *
  * @author Christoph Deppisch
  */
-public class CreateKameletBindingAction extends AbstractCamelKAction {
+public class CreateKameletBindingAction extends AbstractKameletAction {
 
     private final String name;
     private final Integration integration;
@@ -112,7 +111,7 @@ public class CreateKameletBindingAction extends AbstractCamelKAction {
 
         CustomResourceDefinitionContext ctx = CamelKSupport.kameletBindingCRDContext(CamelKSettings.getKameletApiVersion());
         getKubernetesClient().customResources(ctx, KameletBinding.class, KameletBindingList.class)
-                .inNamespace(CamelKSettings.getNamespace())
+                .inNamespace(namespace(context))
                 .createOrReplace(binding);
 
         LOG.info(String.format("Successfully created KameletBinding '%s'", binding.getMetadata().getName()));
@@ -121,7 +120,7 @@ public class CreateKameletBindingAction extends AbstractCamelKAction {
     /**
      * Action builder.
      */
-    public static final class Builder extends AbstractCamelKAction.Builder<CreateKameletBindingAction, Builder> {
+    public static final class Builder extends AbstractKameletAction.Builder<CreateKameletBindingAction, Builder> {
 
         private String name;
         private Integration integration;

--- a/java/steps/yaks-camel-k/src/main/java/org/citrusframework/yaks/camelk/actions/kamelet/DeleteKameletAction.java
+++ b/java/steps/yaks-camel-k/src/main/java/org/citrusframework/yaks/camelk/actions/kamelet/DeleteKameletAction.java
@@ -21,14 +21,13 @@ import com.consol.citrus.context.TestContext;
 import io.fabric8.kubernetes.client.dsl.base.CustomResourceDefinitionContext;
 import org.citrusframework.yaks.camelk.CamelKSettings;
 import org.citrusframework.yaks.camelk.CamelKSupport;
-import org.citrusframework.yaks.camelk.actions.AbstractCamelKAction;
 import org.citrusframework.yaks.camelk.model.Kamelet;
 import org.citrusframework.yaks.camelk.model.KameletList;
 
 /**
  * @author Christoph Deppisch
  */
-public class DeleteKameletAction extends AbstractCamelKAction {
+public class DeleteKameletAction extends AbstractKameletAction {
 
     private final String name;
 
@@ -43,7 +42,7 @@ public class DeleteKameletAction extends AbstractCamelKAction {
         String kameletName = context.replaceDynamicContentInString(name);
         CustomResourceDefinitionContext ctx = CamelKSupport.kameletCRDContext(CamelKSettings.getKameletApiVersion());
         getKubernetesClient().customResources(ctx, Kamelet.class, KameletList.class)
-                .inNamespace(CamelKSettings.getNamespace())
+                .inNamespace(namespace(context))
                 .withName(kameletName)
                 .delete();
     }
@@ -51,7 +50,7 @@ public class DeleteKameletAction extends AbstractCamelKAction {
     /**
      * Action builder.
      */
-    public static class Builder extends AbstractCamelKAction.Builder<DeleteKameletAction, Builder> {
+    public static class Builder extends AbstractKameletAction.Builder<DeleteKameletAction, Builder> {
 
         private String name;
 

--- a/java/steps/yaks-camel-k/src/main/java/org/citrusframework/yaks/camelk/actions/kamelet/DeleteKameletBindingAction.java
+++ b/java/steps/yaks-camel-k/src/main/java/org/citrusframework/yaks/camelk/actions/kamelet/DeleteKameletBindingAction.java
@@ -21,14 +21,13 @@ import com.consol.citrus.context.TestContext;
 import io.fabric8.kubernetes.client.dsl.base.CustomResourceDefinitionContext;
 import org.citrusframework.yaks.camelk.CamelKSettings;
 import org.citrusframework.yaks.camelk.CamelKSupport;
-import org.citrusframework.yaks.camelk.actions.AbstractCamelKAction;
 import org.citrusframework.yaks.camelk.model.KameletBinding;
 import org.citrusframework.yaks.camelk.model.KameletBindingList;
 
 /**
  * @author Christoph Deppisch
  */
-public class DeleteKameletBindingAction extends AbstractCamelKAction {
+public class DeleteKameletBindingAction extends AbstractKameletAction {
 
     private final String name;
 
@@ -43,7 +42,7 @@ public class DeleteKameletBindingAction extends AbstractCamelKAction {
         String bindingName = context.replaceDynamicContentInString(name);
         CustomResourceDefinitionContext ctx = CamelKSupport.kameletBindingCRDContext(CamelKSettings.getKameletApiVersion());
         getKubernetesClient().customResources(ctx, KameletBinding.class, KameletBindingList.class)
-                .inNamespace(CamelKSettings.getNamespace())
+                .inNamespace(namespace(context))
                 .withName(bindingName)
                 .delete();
     }
@@ -51,7 +50,7 @@ public class DeleteKameletBindingAction extends AbstractCamelKAction {
     /**
      * Action builder.
      */
-    public static class Builder extends AbstractCamelKAction.Builder<DeleteKameletBindingAction, Builder> {
+    public static class Builder extends AbstractKameletAction.Builder<DeleteKameletBindingAction, Builder> {
 
         private String name;
 

--- a/java/steps/yaks-camel-k/src/main/java/org/citrusframework/yaks/camelk/actions/kamelet/VerifyKameletAction.java
+++ b/java/steps/yaks-camel-k/src/main/java/org/citrusframework/yaks/camelk/actions/kamelet/VerifyKameletAction.java
@@ -23,7 +23,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import io.fabric8.kubernetes.client.dsl.base.CustomResourceDefinitionContext;
 import org.citrusframework.yaks.camelk.CamelKSettings;
 import org.citrusframework.yaks.camelk.CamelKSupport;
-import org.citrusframework.yaks.camelk.actions.AbstractCamelKAction;
 import org.citrusframework.yaks.camelk.model.Kamelet;
 import org.citrusframework.yaks.camelk.model.KameletList;
 import org.citrusframework.yaks.kubernetes.KubernetesSupport;
@@ -33,7 +32,7 @@ import org.citrusframework.yaks.kubernetes.KubernetesSupport;
  *
  * @author Christoph Deppisch
  */
-public class VerifyKameletAction extends AbstractCamelKAction {
+public class VerifyKameletAction extends AbstractKameletAction {
 
     private final String name;
 
@@ -51,12 +50,12 @@ public class VerifyKameletAction extends AbstractCamelKAction {
         String kameletName = context.replaceDynamicContentInString(name);
         CustomResourceDefinitionContext ctx = CamelKSupport.kameletCRDContext(CamelKSettings.getKameletApiVersion());
         Kamelet kamelet = getKubernetesClient().customResources(ctx, Kamelet.class, KameletList.class)
-                .inNamespace(CamelKSettings.getNamespace())
+                .inNamespace(namespace(context))
                 .withName(kameletName)
                 .get();
 
         if (kamelet == null) {
-            throw new ValidationException(String.format("Failed to retrieve Kamelet '%s' in namespace '%s'", name, CamelKSettings.getNamespace()));
+            throw new ValidationException(String.format("Failed to retrieve Kamelet '%s' in namespace '%s'", name, namespace(context)));
         }
 
         LOG.info("Kamlet validation successful - All values OK!");
@@ -72,7 +71,7 @@ public class VerifyKameletAction extends AbstractCamelKAction {
     /**
      * Action builder.
      */
-    public static final class Builder extends AbstractCamelKAction.Builder<VerifyKameletAction, Builder> {
+    public static final class Builder extends AbstractKameletAction.Builder<VerifyKameletAction, Builder> {
 
         private String name;
 

--- a/java/steps/yaks-camel-k/src/main/java/org/citrusframework/yaks/camelk/actions/kamelet/VerifyKameletBindingAction.java
+++ b/java/steps/yaks-camel-k/src/main/java/org/citrusframework/yaks/camelk/actions/kamelet/VerifyKameletBindingAction.java
@@ -23,7 +23,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import io.fabric8.kubernetes.client.dsl.base.CustomResourceDefinitionContext;
 import org.citrusframework.yaks.camelk.CamelKSettings;
 import org.citrusframework.yaks.camelk.CamelKSupport;
-import org.citrusframework.yaks.camelk.actions.AbstractCamelKAction;
 import org.citrusframework.yaks.camelk.model.KameletBinding;
 import org.citrusframework.yaks.camelk.model.KameletBindingList;
 import org.citrusframework.yaks.kubernetes.KubernetesSupport;
@@ -33,7 +32,7 @@ import org.citrusframework.yaks.kubernetes.KubernetesSupport;
  *
  * @author Christoph Deppisch
  */
-public class VerifyKameletBindingAction extends AbstractCamelKAction {
+public class VerifyKameletBindingAction extends AbstractKameletAction {
 
     private final String name;
 
@@ -51,12 +50,12 @@ public class VerifyKameletBindingAction extends AbstractCamelKAction {
         String bindingName = context.replaceDynamicContentInString(name);
         CustomResourceDefinitionContext ctx = CamelKSupport.kameletBindingCRDContext(CamelKSettings.getKameletApiVersion());
         KameletBinding binding = getKubernetesClient().customResources(ctx, KameletBinding.class, KameletBindingList.class)
-                .inNamespace(CamelKSettings.getNamespace())
+                .inNamespace(namespace(context))
                 .withName(bindingName)
                 .get();
 
         if (binding == null) {
-            throw new ValidationException(String.format("Failed to retrieve KameletBinding '%s' in namespace '%s'", name, CamelKSettings.getNamespace()));
+            throw new ValidationException(String.format("Failed to retrieve KameletBinding '%s' in namespace '%s'", name, namespace(context)));
         }
 
         LOG.info("KamletBinding validation successful - All values OK!");
@@ -72,7 +71,7 @@ public class VerifyKameletBindingAction extends AbstractCamelKAction {
     /**
      * Action builder.
      */
-    public static final class Builder extends AbstractCamelKAction.Builder<VerifyKameletBindingAction, Builder> {
+    public static final class Builder extends AbstractKameletAction.Builder<VerifyKameletBindingAction, Builder> {
 
         private String name;
 

--- a/java/steps/yaks-kubernetes/src/test/java/org/citrusframework/yaks/kubernetes/KubernetesTestSteps.java
+++ b/java/steps/yaks-kubernetes/src/test/java/org/citrusframework/yaks/kubernetes/KubernetesTestSteps.java
@@ -108,14 +108,14 @@ public class KubernetesTestSteps {
                 Pod pod = new PodBuilder()
                         .withNewMetadata()
                         .withName(podName)
-                        .withNamespace(KubernetesSettings.getNamespace())
+                        .withNamespace(namespace(context))
                         .endMetadata()
                         .withNewStatus()
                         .withPhase(status)
                         .endStatus()
                         .build();
 
-                getKubernetesClient().pods().inNamespace(KubernetesSettings.getNamespace()).create(pod);
+                getKubernetesClient().pods().inNamespace(namespace(context)).create(pod);
             }
         });
     }
@@ -133,7 +133,7 @@ public class KubernetesTestSteps {
                 Pod pod = new PodBuilder()
                         .withNewMetadata()
                         .withName(podName)
-                        .withNamespace(KubernetesSettings.getNamespace())
+                        .withNamespace(namespace(context))
                         .withLabels(Collections.singletonMap(label, value))
                         .endMetadata()
                         .withNewStatus()
@@ -141,7 +141,7 @@ public class KubernetesTestSteps {
                         .endStatus()
                         .build();
 
-                getKubernetesClient().pods().inNamespace(KubernetesSettings.getNamespace()).create(pod);
+                getKubernetesClient().pods().inNamespace(namespace(context)).create(pod);
             }
         });
     }


### PR DESCRIPTION
Adding new step `@Given("^Camel K namespace ([^\\s]+)$")` and `@Given("^Kamelet namespace ([^\\s]+)$")`

- Users can use the step to explicitly set the namespace for upcoming Camel K operations. This overwrites the env variable settings in yaks-config.yaml.
- Camel K and Kamelets do have separate namespace settings and steps respectively.
- Fix Kubernetes namespace usage in test actions so steps fully control the namespace to use.