### PR TITLE
chore: Improve mvn runtime startup times

### DIFF
--- a/java/runtime/yaks-runtime-maven/pom.xml
+++ b/java/runtime/yaks-runtime-maven/pom.xml
@@ -143,6 +143,51 @@
         </plugin>
       </plugins>
     </pluginManagement>
+
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-remote-resources-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-site-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+        <configuration>
+          <skipSource>true</skipSource>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+    </plugins>
   </build>
 
   <profiles>

--- a/pkg/controller/test/start.go
+++ b/pkg/controller/test/start.go
@@ -246,7 +246,7 @@ func getMavenArgLine() []string {
 	argLine := make([]string, 0)
 
 	// add base flags
-	argLine = append(argLine, "mvn", "-B", "-q")
+	argLine = append(argLine, "mvn", "-B", "-q", "--no-snapshot-updates", "--no-transfer-progress")
 
 	// add pom file path
 	argLine = append(argLine, "-f", "/deployments/data/yaks-runtime-maven")
@@ -255,10 +255,10 @@ func getMavenArgLine() []string {
 	argLine = append(argLine, "-s", "/deployments/artifacts/settings.xml")
 
 	// add test goal
-	argLine = append(argLine, "verify")
+	argLine = append(argLine, "resources:testResources", "compiler:testCompile", "failsafe:integration-test")
 
 	// add system property settings
-	argLine = append(argLine, "-Dremoteresources.skip=true", "-Dmaven.repo.local=/deployments/artifacts/m2")
+	argLine = append(argLine, "-Dmaven.repo.local=/deployments/artifacts/m2")
 
 	return argLine
 }


### PR DESCRIPTION
- Disable unused plugins
- Call Maven lifecycle phases (test compile, integration test) directly instead of running the whole lifecycle