### PR TITLE
chore: Make runAsUser configurable

### DIFF
--- a/pkg/apis/yaks/v1alpha1/test_types.go
+++ b/pkg/apis/yaks/v1alpha1/test_types.go
@@ -73,12 +73,14 @@ type SettingsSpec struct {
 
 // SeleniumSpec
 type SeleniumSpec struct {
-	Image string `json:"image,omitempty"`
+	Image     string `json:"image,omitempty"`
+	RunAsUser int    `json:"runAsUser,omitempty"`
 }
 
 // KubeDockSpec
 type KubeDockSpec struct {
-	Image string `json:"image,omitempty"`
+	Image     string `json:"image,omitempty"`
+	RunAsUser int    `json:"runAsUser,omitempty"`
 }
 
 // TestStatus defines the observed state of Test

--- a/pkg/cmd/config/config.go
+++ b/pkg/cmd/config/config.go
@@ -70,11 +70,13 @@ type CucumberConfig struct {
 }
 
 type SeleniumConfig struct {
-	Image string `yaml:"image"`
+	Image     string `yaml:"image"`
+	RunAsUser int    `yaml:"runAsUser"`
 }
 
 type TestContainersConfig struct {
-	Enabled bool `yaml:"enabled"`
+	Enabled   bool `yaml:"enabled"`
+	RunAsUser int  `yaml:"runAsUser"`
 }
 
 type EnvConfig struct {

--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -484,13 +484,15 @@ func (o *runCmdOptions) createAndRunTest(cmd *cobra.Command, c client.Client, ra
 
 	if runConfig.Config.Runtime.Selenium.Image != "" {
 		test.Spec.Selenium = v1alpha1.SeleniumSpec{
-			Image: runConfig.Config.Runtime.Selenium.Image,
+			Image:     runConfig.Config.Runtime.Selenium.Image,
+			RunAsUser: runConfig.Config.Runtime.Selenium.RunAsUser,
 		}
 	}
 
 	if runConfig.Config.Runtime.TestContainers.Enabled {
 		test.Spec.KubeDock = v1alpha1.KubeDockSpec{
-			Image: "joyrex2001/kubedock:0.8.1",
+			Image:     "joyrex2001/kubedock:0.8.1",
+			RunAsUser: runConfig.Config.Runtime.TestContainers.RunAsUser,
 		}
 	}
 

--- a/pkg/controller/test/start.go
+++ b/pkg/controller/test/start.go
@@ -39,7 +39,7 @@ import (
 )
 
 const (
-	NonRootUser = 1000700001
+	RunAsUser = 1001 // non-root user must match id used in Dockerfile
 )
 
 // NewStartAction creates a new start action
@@ -497,7 +497,11 @@ func (action *startAction) addSelenium(test *v1alpha1.Test, job *batchv1.Job) {
 		job.Spec.Template.Spec.ShareProcessNamespace = &shareProcessNamespace
 
 		// set explicit non-root user for all containers - required for killing the supervisord process later
-		uid := int64(NonRootUser)
+		uid := int64(RunAsUser)
+		if test.Spec.Selenium.RunAsUser > 0 {
+			uid = int64(test.Spec.Selenium.RunAsUser)
+		}
+
 		job.Spec.Template.Spec.SecurityContext = &v1.PodSecurityContext{
 			RunAsUser: &uid,
 		}
@@ -541,7 +545,11 @@ func (action *startAction) addKubeDock(test *v1alpha1.Test, job *batchv1.Job) {
 		job.Spec.Template.Spec.ShareProcessNamespace = &shareProcessNamespace
 
 		// set explicit non-root user for all containers - required for killing the supervisord process later
-		uid := int64(NonRootUser)
+		uid := int64(RunAsUser)
+		if test.Spec.KubeDock.RunAsUser > 0 {
+			uid = int64(test.Spec.KubeDock.RunAsUser)
+		}
+
 		job.Spec.Template.Spec.SecurityContext = &v1.PodSecurityContext{
 			RunAsUser: &uid,
 		}


### PR DESCRIPTION
Kubedock (use for Testcontainers) and Selenium sidecars use the runAsUser setting provided in yaks-config.yaml