### PR TITLE
fix(#316): Indicate test result status in post scripts

### DIFF
--- a/java/docs/pre-post-scripts.adoc
+++ b/java/docs/pre-post-scripts.adoc
@@ -23,21 +23,57 @@ post:
   - run: echo Bye!
 ----
 
-The section `pre` runs before a test group and `post` is added after the test group has finished. The post steps are run even if the tests or pre steps fail
-for some reason. This ensures that cleanup tasks are performed also in case of errors.
+The section `pre` runs before a test group and `post` is added after the test group has finished.
+The post steps are run even if the tests or pre steps fail for some reason.
+This ensures that cleanup tasks are performed also in case of errors.
 
-The `script` option provides a file path to bash script to execute. The user has to make sure that the script is executable. If no absolute file path is
-given it is assumed to be a file path relative to the current test group directory.
+The `script` option provides a file path to bash script to execute.
+The user has to make sure that the script is executable.
+If no absolute file path is given it is assumed to be a file path relative to the current test group directory.
 
-With `run` you can add any shell command. At the moment only single line commands are supported here. You can add multiple `run` commands in a `pre`
-or `post` section.
+With `run` you can add any shell command inline.
+You can add multiple `run` commands in a `pre` or `post` section.
 
-Each step can also define a human readable `name` that will be printed before its execution.
+Each step can also define a human-readable `name` that will be printed before its execution.
 
-By default a step must complete within 30 minutes (`30m`). The timeout can be changed using the `timeout` option in the step declaration (in Golang duration format).
+By default, a step must complete within 30 minutes (`30m`).
+The timeout can be changed using the `timeout` option in the step declaration (in Golang duration format).
 
-Scripts can leverage the following environment variables that are set automatically by the Yaks runtime:
+[[scripts-env]]
+== Environment variables in scripts
+
+Scripts can leverage the following environment variables that are set automatically by the YAKS runtime:
 
 - **YAKS_NAMESPACE**: always contains the namespace where the tests will be executed, no matter if the namespace is fixed or temporary
+- **YAKS_TEST_STATUS**: indicates the test status (SUCCESS, FAILED)
 
+[[conditional-scripts]]
+== Conditional execution
 
+You can add conditions so scripts are run based on condition evaluation.
+Just add `if` section to the 'pre/post' script configuration.
+
+[source,yaml]
+----
+config:
+  namespace:
+    temporary: false
+    autoRemove: true
+pre:
+  - name: Install
+    if: "os=darwin"
+    run: |
+      echo "Runs on MacOS"
+post:
+  - name: CleanUp
+    if: "env:foo=bar"
+    script: finish.sh
+----
+
+The condition expressions support evaluation based on:
+
+* Test failure: `failure()`
+* Operating system: `os={name}`
+* Environment variables: `env{name}={value}`
+
+Scripts that define an `if` statement only execute when respective expression evaluation is true.


### PR DESCRIPTION
- Add `failure()` condition in script execution
- Add test status (SUCCESS, FAILED) indicator as script environment variable