### PR TITLE
chore: Fix test dumps and PostgreSQL testcontainer waiting strategy

### DIFF
--- a/java/steps/yaks-testcontainers/src/main/java/org/citrusframework/yaks/testcontainers/PostgreSQLSteps.java
+++ b/java/steps/yaks-testcontainers/src/main/java/org/citrusframework/yaks/testcontainers/PostgreSQLSteps.java
@@ -99,7 +99,7 @@ public class PostgreSQLSteps {
                 .withUsername(username)
                 .withPassword(password)
                 .withDatabaseName(databaseName)
-                .waitingFor(Wait.forLogMessage(".*database system is ready to accept connections.*\\s", 2)
+                .waitingFor(Wait.forListeningPort()
                         .withStartupTimeout(Duration.of(startupTimeout, SECONDS)));
 
         postgreSQLContainer.start();

--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -617,7 +617,9 @@ func (o *runCmdOptions) createAndRunTest(cmd *cobra.Command, c client.Client, ra
 	}
 
 	if runConfig.Config.Dump.Enabled {
-		if runConfig.Config.Dump.FailedOnly && len(test.Status.Results.Errors) == 0 {
+		if runConfig.Config.Dump.FailedOnly &&
+			test.Status.Phase != v1alpha1.TestPhaseFailed && test.Status.Phase != v1alpha1.TestPhaseError &&
+			len(test.Status.Errors) == 0 && !hasSuiteErrors(&test.Status.Results) {
 			fmt.Println("Skip dump for successful test")
 		} else {
 			var fileName string

--- a/pkg/cmd/util.go
+++ b/pkg/cmd/util.go
@@ -226,9 +226,17 @@ func resolvePath(runConfig *config.RunConfig, resource string) string {
 
 func hasErrors(results *v1alpha1.TestResults) bool {
 	for _, suite := range results.Suites {
-		if len(suite.Errors) > 0 || suite.Summary.Errors > 0 || suite.Summary.Failed > 0 {
+		if hasSuiteErrors(&suite) {
 			return true
 		}
+	}
+
+	return false
+}
+
+func hasSuiteErrors(suite *v1alpha1.TestSuite) bool {
+	if len(suite.Errors) > 0 || suite.Summary.Errors > 0 || suite.Summary.Failed > 0 {
+		return true
 	}
 
 	return false


### PR DESCRIPTION
# chore: Fix test dumps on failure
- Make sure to evaluate proper test failure state when creating dumps on failure

# chore: Change waiting strategy on PostgreSQL testcontainer
- Change startup waiting strategy from logs to listening port as waiting for log output has been flaky in Kubedock setup