### PR TITLE
fix(#411): Fix pre test script error handling

### DIFF
--- a/pkg/apis/yaks/v1alpha1/instance_types_support.go
+++ b/pkg/apis/yaks/v1alpha1/instance_types_support.go
@@ -19,29 +19,91 @@ package v1alpha1
 
 import (
 	"context"
+
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/citrusframework/yaks/pkg/util/envvar"
 )
 
-// GetInstance return the YAKS operator instance in given namespace
-func GetInstance(ctx context.Context, client ctrl.Client, namespace string) (*Instance, error) {
-	instance := Instance{
+// NewInstanceList --
+func NewInstanceList() InstanceList {
+	return InstanceList{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       InstanceKind,
 			APIVersion: SchemeGroupVersion.String(),
 		},
 	}
+}
 
-	key := ctrl.ObjectKey{
-		Namespace: namespace,
-		Name:      "yaks",
+// NewInstance --
+func NewInstance(namespace string, name string) Instance {
+	return Instance{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       InstanceKind,
+			APIVersion: SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+		},
+	}
+}
+
+// GetOrFindInstance return the YAKS operator instance in given namespace or the operator namespace.
+func GetOrFindInstance(ctx context.Context, client ctrl.Client, namespace string) (*Instance, error) {
+	instance, err := GetInstance(ctx, client, namespace)
+	if err != nil && k8serrors.IsNotFound(err) {
+		if operatorNamespace, envErr := envvar.GetOperatorNamespace(); envErr == nil {
+			if operatorNamespace != "" && operatorNamespace != namespace {
+				instance, err = GetInstance(ctx, client, operatorNamespace)
+				if err != nil {
+					return nil, err
+				}
+			} else {
+				return nil, err
+			}
+		} else {
+			return nil, err
+		}
 	}
 
-	if err := client.Get(ctx, key, &instance); err != nil {
+	return instance, err
+}
+
+// GetInstance return the YAKS operator instance in given namespace.
+func GetInstance(ctx context.Context, client ctrl.Client, namespace string) (*Instance, error) {
+	instance := NewInstance(namespace, "yaks")
+	if err := client.Get(ctx, ctrl.ObjectKeyFromObject(&instance), &instance); err != nil {
 		return nil, err
 	}
 
 	return &instance, nil
+}
+
+// FindGlobalInstance list instances on the cluster and get the first global match.
+func FindGlobalInstance(ctx context.Context, c ctrl.Client) (*Instance, error) {
+	// looking for operator instances in other namespaces
+	instanceList, err := ListInstances(ctx, c)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, instance := range instanceList.Items {
+		if instance.Spec.Operator.Global {
+			return &instance, nil
+		}
+	}
+
+	return nil, nil
+}
+
+// ListInstances lists all instances on the cluster.
+func ListInstances(ctx context.Context, c ctrl.Client) (InstanceList, error) {
+	instanceList := NewInstanceList()
+	err := c.List(ctx, &instanceList)
+	return instanceList, err
 }
 
 // IsGlobal returns true if the given instance is configured to watch all namespaces

--- a/pkg/cmd/dump.go
+++ b/pkg/cmd/dump.go
@@ -21,10 +21,10 @@ import (
 	"bufio"
 	"context"
 	"fmt"
-	"github.com/citrusframework/yaks/pkg/apis/yaks/v1alpha1"
 	"io"
 	"os"
 
+	"github.com/citrusframework/yaks/pkg/apis/yaks/v1alpha1"
 	"github.com/citrusframework/yaks/pkg/client"
 	"github.com/citrusframework/yaks/pkg/client/yaks/clientset/versioned"
 	"github.com/citrusframework/yaks/pkg/cmd/config"
@@ -34,6 +34,7 @@ import (
 
 	"github.com/spf13/cobra"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -268,8 +269,8 @@ func dumpOperator(yaksClient *versioned.Clientset, ctx context.Context, c client
 
 	if len(instances.Items) == 0 {
 		// looking for global operator instance
-		instance, err := findGlobalInstance(ctx, c)
-		if err != nil {
+		instance, err := v1alpha1.FindGlobalInstance(ctx, c)
+		if err != nil && !errors.IsForbidden(err) {
 			return err
 		}
 


### PR DESCRIPTION
Make sure to only skip the current test that has errors in pre test scripts. The other tests in the same test group should continue to run as usual.

Fixes #411 