### PR TITLE
fix(#423): Support build properties on Camel K integration

### DIFF
--- a/java/steps/yaks-camel-k/src/main/java/org/citrusframework/yaks/camelk/CamelKSteps.java
+++ b/java/steps/yaks-camel-k/src/main/java/org/citrusframework/yaks/camelk/CamelKSteps.java
@@ -62,6 +62,8 @@ public class CamelKSteps {
 
     private List<String> propertyFiles;
     private Map<String, String> properties;
+    private List<String> buildPropertyFiles;
+    private Map<String, String> buildProperties;
 
     private boolean supportVariablesInSources = CamelKSettings.isSupportVariablesInSources();
 
@@ -73,6 +75,8 @@ public class CamelKSteps {
 
         propertyFiles = new ArrayList<>();
         properties = new LinkedHashMap<>();
+        buildPropertyFiles = new ArrayList<>();
+        buildProperties = new LinkedHashMap<>();
     }
 
     @Given("^Disable auto removal of Camel K resources$")
@@ -123,6 +127,22 @@ public class CamelKSteps {
         properties.putAll(propertyTable.asMap(String.class, String.class));
     }
 
+    @Given("^Camel K integration build property file ([^\\s]+)$")
+    public void addBuildPropertyFile(String filePath) {
+        buildPropertyFiles.add(filePath);
+    }
+
+	@Given("^Camel K integration build property ([^\\s]+)=\"([^\"]*)\"$")
+    @Given("^Camel K integration build property ([^\\s]+) (?:is|=) \"([^\"]*)\"$")
+    public void addBuildProperty(String name, String value) {
+        buildProperties.put(name, value);
+    }
+
+	@Given("^Camel K integration build properties$")
+    public void addBuildProperties(DataTable propertyTable) {
+        buildProperties.putAll(propertyTable.asMap(String.class, String.class));
+    }
+
 	@Given("^(?:create|new) Camel K integration ([a-z0-9][a-z0-9-\\.]+[a-z0-9])\\.([a-z0-9-]+) with configuration:?$")
 	public void createIntegration(String name, String language, Map<String, String> configuration) {
 		if (configuration.get("source") == null) {
@@ -157,7 +177,10 @@ public class CamelKSteps {
         runner.run(camelk()
                     .client(k8sClient)
                     .createIntegration(name + "." + language)
+                    .properties(properties)
                     .propertyFiles(propertyFiles)
+                    .buildProperties(buildProperties)
+                    .buildPropertyFiles(buildPropertyFiles)
                     .supportVariables(supportVariablesInSources)
                     .source(source));
 
@@ -225,6 +248,9 @@ public class CamelKSteps {
                 .createIntegration(configuration.getOrDefault("name", name + "." + language))
                 .source(name + "." + language, source)
                 .dependencies(configuration.getOrDefault("dependencies", "").trim())
+                .buildProperties(configuration.getOrDefault("build-properties", "").trim())
+                .buildProperties(buildProperties)
+                .buildPropertyFiles(buildPropertyFiles)
                 .properties(configuration.getOrDefault("properties", "").trim())
                 .properties(properties)
                 .propertyFiles(propertyFiles)

--- a/java/steps/yaks-camel-k/src/main/java/org/citrusframework/yaks/camelk/model/Integration.java
+++ b/java/steps/yaks-camel-k/src/main/java/org/citrusframework/yaks/camelk/model/Integration.java
@@ -19,6 +19,7 @@ package org.citrusframework.yaks.camelk.model;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -49,10 +50,10 @@ public class Integration extends CustomResource<IntegrationSpec, IntegrationStat
 	 * Fluent builder
 	 */
 	public static class Builder {
-		private Map<String, IntegrationSpec.TraitConfig> traits;
+		private final Map<String, IntegrationSpec.TraitConfig> traits = new LinkedHashMap<>();
 		private final List<IntegrationSpec.Resource> resources = new ArrayList<>();
-		private List<String> dependencies;
-		private List<IntegrationSpec.Configuration> configuration;
+		private final List<String> dependencies = new ArrayList<>();
+		private final List<IntegrationSpec.Configuration> configuration = new ArrayList<>();
 		private String source;
 		private String fileName;
 		private String name;
@@ -84,17 +85,22 @@ public class Integration extends CustomResource<IntegrationSpec, IntegrationStat
 		}
 
 		public Builder dependencies(List<String> dependencies) {
-			this.dependencies = Collections.unmodifiableList(dependencies);
+			this.dependencies.addAll(dependencies);
 			return this;
 		}
 
 		public Builder traits(Map<String, IntegrationSpec.TraitConfig> traits) {
-			this.traits = Collections.unmodifiableMap(traits);
+			this.traits.putAll(traits);
+			return this;
+		}
+
+		public Builder trait(String name, IntegrationSpec.TraitConfig config) {
+			this.traits.put(name ,config);
 			return this;
 		}
 
 		public Builder configuration(List<IntegrationSpec.Configuration> configuration) {
-			this.configuration = Collections.unmodifiableList(configuration);
+			this.configuration.addAll(configuration);
 			return this;
 		}
 
@@ -102,9 +108,18 @@ public class Integration extends CustomResource<IntegrationSpec, IntegrationStat
 			Integration i = new Integration();
 			i.getMetadata().setName(sanitizeIntegrationName(name));
 			i.getSpec().setSources(Collections.singletonList(new IntegrationSpec.Source(fileName, source)));
-			i.getSpec().setDependencies(dependencies);
-			i.getSpec().setTraits(traits);
-			i.getSpec().setConfiguration(configuration);
+
+			if (!dependencies.isEmpty()) {
+				i.getSpec().setDependencies(dependencies);
+			}
+
+			if (!traits.isEmpty()) {
+				i.getSpec().setTraits(traits);
+			}
+
+			if (!configuration.isEmpty()) {
+				i.getSpec().setConfiguration(configuration);
+			}
 
 			if (!resources.isEmpty()) {
 				i.getSpec().setResources(resources);

--- a/java/steps/yaks-camel-k/src/main/java/org/citrusframework/yaks/camelk/model/IntegrationSpec.java
+++ b/java/steps/yaks-camel-k/src/main/java/org/citrusframework/yaks/camelk/model/IntegrationSpec.java
@@ -185,14 +185,13 @@ public class IntegrationSpec implements KubernetesResource {
     @JsonPropertyOrder({"configuration"})
     public static class TraitConfig {
         @JsonProperty("configuration")
-        private Map<String, Object> configuration;
+        private Map<String, Object> configuration = new HashMap<>();
 
         public TraitConfig() {
-            this.configuration = new HashMap<>();
+            // default constructor
         }
 
         public TraitConfig(String key, Object value) {
-            this.configuration = new HashMap<>();
             add(key, value);
         }
 

--- a/java/steps/yaks-camel-k/src/test/java/org.citrusframework.yaks.camelk/IntegrationBuilderTest.java
+++ b/java/steps/yaks-camel-k/src/test/java/org.citrusframework.yaks.camelk/IntegrationBuilderTest.java
@@ -78,6 +78,10 @@ public class IntegrationBuilderTest {
 		traits.put("quarkus", quarkus);
 		traits.put("route", new IntegrationSpec.TraitConfig("enabled", true));
 
+		IntegrationSpec.TraitConfig builder = new IntegrationSpec.TraitConfig("properties", Arrays.asList("quarkus.foo=bar", "quarkus.verbose=true"));
+		builder.add("verbose", true);
+		traits.put("builder", builder);
+
 		List<String> dependencies = Arrays.asList("mvn:fake.dependency:id:version-1", "camel:jackson");
 		Integration i = new Integration.Builder()
 				.name("bar.groovy")

--- a/java/steps/yaks-camel-k/src/test/resources/org/citrusframework/yaks/camelk/integration.json
+++ b/java/steps/yaks-camel-k/src/test/resources/org/citrusframework/yaks/camelk/integration.json
@@ -26,6 +26,12 @@
           "native": "true",
           "enabled": true
         }
+      },
+      "builder":{
+        "configuration": {
+          "properties": ["quarkus.foo=bar","quarkus.verbose=true"],
+          "verbose": true
+        }
       }
     }
   }


### PR DESCRIPTION
- Add steps to set build properties on the Camel K integration
- Allow trait config (e.g. builder.properties) to have multiple values for the same key as a list

Fixes #423 