### PR TITLE
fix(#426): Support config modeline setting on Camel K integration

### DIFF
--- a/java/steps/yaks-camel-k/src/main/java/org/citrusframework/yaks/camelk/actions/integration/CreateIntegrationAction.java
+++ b/java/steps/yaks-camel-k/src/main/java/org/citrusframework/yaks/camelk/actions/integration/CreateIntegrationAction.java
@@ -102,6 +102,7 @@ public class CreateIntegrationAction extends AbstractCamelKAction {
         }
         addPropertyConfigurationSpec(integrationBuilder, context);
         addBuildPropertyConfigurationSpec(integrationBuilder, resolvedSource, context);
+        addRuntimeConfigurationSpec(integrationBuilder, resolvedSource, context);
         addTraitSpec(integrationBuilder, resolvedSource, context);
         addOpenApiSpec(integrationBuilder, context);
 
@@ -262,6 +263,25 @@ public class CreateIntegrationAction extends AbstractCamelKAction {
 
         if (!traitConfigMap.isEmpty()) {
             integrationBuilder.traits(traitConfigMap);
+        }
+    }
+
+    private void addRuntimeConfigurationSpec(Integration.Builder integrationBuilder, String source, TestContext context) {
+        final List<IntegrationSpec.Configuration> configurationList = new ArrayList<>();
+
+        Pattern pattern = getModelinePattern("config");
+        Matcher depMatcher = pattern.matcher(source);
+        while (depMatcher.find()) {
+            String[] config = depMatcher.group(1).split(":", 2);
+            if (config.length == 2) {
+                configurationList.add(new IntegrationSpec.Configuration(config[0], config[1]));
+            } else {
+                configurationList.add(new IntegrationSpec.Configuration("property", depMatcher.group(1)));
+            }
+        }
+
+        if (!configurationList.isEmpty()) {
+            integrationBuilder.configuration(configurationList);
         }
     }
 


### PR DESCRIPTION
Allow to set secrets, configmap, properties as runtime configuration via modeline

Fixes #426 