### PR TITLE
fix(#438): Add Xml test runtime

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -132,6 +132,7 @@ jobs:
         # Eventually `yaks run examples` should work
 
         # For now:
+        yaks run examples/xml $YAKS_RUN_OPTIONS
         yaks run examples/groovy $YAKS_RUN_OPTIONS
         yaks run examples/camel $YAKS_RUN_OPTIONS
         yaks run examples/camel-k $YAKS_RUN_OPTIONS

--- a/examples/xml/messaging-test.xml
+++ b/examples/xml/messaging-test.xml
@@ -1,0 +1,47 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<test name="MessagingTest" author="Christoph" status="FINAL" xmlns="http://citrusframework.org/schema/xml/testcase"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://citrusframework.org/schema/xml/testcase http://citrusframework.org/schema/xml/testcase/citrus-testcase.xsd">
+    <variables>
+        <variable name="message" value="YAKS rocks!"/>
+    </variables>
+    <actions>
+        <send endpoint="direct:hello">
+            <message>
+                <headers>
+                    <header name="operation" value="sayHELLO"/>
+                </headers>
+                <body>
+                    <data>${message}</data>
+                </body>
+            </message>
+        </send>
+
+        <receive endpoint="direct:hello">
+            <message>
+                <headers>
+                    <header name="operation" value="sayHELLO"/>
+                </headers>
+                <body>
+                    <data>${message}</data>
+                </body>
+            </message>
+        </receive>
+    </actions>
+</test>

--- a/examples/xml/sample-test.xml
+++ b/examples/xml/sample-test.xml
@@ -1,0 +1,28 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<test name="SampleTest" author="Christoph" status="FINAL" xmlns="http://citrusframework.org/schema/xml/testcase"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://citrusframework.org/schema/xml/testcase http://citrusframework.org/schema/xml/testcase/citrus-testcase.xsd">
+    <description>Sample test in XML</description>
+    <variables>
+        <variable name="message" value="YAKS rocks!"/>
+    </variables>
+    <actions>
+        <echo message="Today's headline: ${message}"/>
+    </actions>
+</test>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -193,6 +193,11 @@
       </dependency>
       <dependency>
         <groupId>com.consol.citrus</groupId>
+        <artifactId>citrus-xml</artifactId>
+        <version>${citrus.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.consol.citrus</groupId>
         <artifactId>citrus-validation-json</artifactId>
         <version>${citrus.version}</version>
       </dependency>

--- a/java/runtime/yaks-runtime-maven/pom.xml
+++ b/java/runtime/yaks-runtime-maven/pom.xml
@@ -127,6 +127,10 @@
     </dependency>
     <dependency>
       <groupId>com.consol.citrus</groupId>
+      <artifactId>citrus-xml</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.consol.citrus</groupId>
       <artifactId>citrus-validation-json</artifactId>
     </dependency>
     <dependency>

--- a/java/runtime/yaks-runtime-maven/src/test/java/org/citrusframework/yaks/xml/Yaks_IT.java
+++ b/java/runtime/yaks-runtime-maven/src/test/java/org/citrusframework/yaks/xml/Yaks_IT.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.yaks.xml;
+
+import java.io.IOException;
+import java.io.Writer;
+import java.nio.file.Files;
+import java.nio.file.StandardOpenOption;
+import java.util.UUID;
+
+import com.consol.citrus.annotations.CitrusTestSource;
+import com.consol.citrus.common.TestLoader;
+import com.consol.citrus.junit.spring.JUnit4CitrusSpringSupport;
+import com.consol.citrus.report.TestReporter;
+import com.consol.citrus.report.TestResults;
+import org.citrusframework.yaks.YaksSettings;
+import org.citrusframework.yaks.report.TestResult;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.ContextConfiguration;
+
+/**
+ * @author Christoph Deppisch
+ */
+@ContextConfiguration(classes = Yaks_IT.Config.class)
+public class Yaks_IT extends JUnit4CitrusSpringSupport {
+
+    @Test
+    @CitrusTestSource(type = TestLoader.XML, packageScan = "org.citrusframework.yaks.xml")
+    public void yaksXml_IT() {
+    }
+
+    @Configuration
+    public static class Config {
+
+        /** Logger */
+        private static final Logger LOG = LoggerFactory.getLogger(Config.class);
+
+        @Bean
+        public TestReporter terminationLogReporter() {
+            return testResults -> {
+                try (Writer terminationLogWriter = Files.newBufferedWriter(YaksSettings.getTerminationLog(),
+                        StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING)) {
+                    terminationLogWriter.write(convertResults(testResults).toJson());
+                    terminationLogWriter.flush();
+                } catch (IOException e) {
+                    LOG.warn(String.format("Failed to write termination logs to file '%s'", YaksSettings.getTerminationLog()), e);
+                }
+            };
+        }
+
+        private static org.citrusframework.yaks.report.TestResults convertResults(TestResults testResults) {
+            org.citrusframework.yaks.report.TestResults results = new org.citrusframework.yaks.report.TestResults();
+
+            testResults.doWithResults(r ->
+                    results.addTestResult(new TestResult(UUID.randomUUID(), r.getTestName(), r.getClassName(), r.getCause())));
+
+            results.getSummary().passed = testResults.getSuccess();
+            results.getSummary().failed = testResults.getFailed();
+            results.getSummary().skipped = testResults.getSkipped();
+
+            return results;
+        }
+    }
+}

--- a/java/tools/maven/yaks-maven-extension/src/main/java/org/citrusframework/yaks/maven/extension/ProjectModelEnricher.java
+++ b/java/tools/maven/yaks-maven-extension/src/main/java/org/citrusframework/yaks/maven/extension/ProjectModelEnricher.java
@@ -62,7 +62,7 @@ public class ProjectModelEnricher implements ProjectExecutionListener {
     Logger logger;
 
     /** Set of supported source test types */
-    private static final String[] SOURCE_TYPES = new String[] {".feature", "it.groovy", "test.groovy"};
+    private static final String[] SOURCE_TYPES = new String[] {".feature", "it.groovy", "test.groovy", "it.xml", "test.xml"};
 
     @Override
     public void beforeProjectExecution(ProjectExecutionEvent projectExecutionEvent) throws LifecycleExecutionException {

--- a/java/tools/maven/yaks-maven-extension/src/test/java/org/citrusframework/yaks/maven/extension/ProjectModelEnricherTest.java
+++ b/java/tools/maven/yaks-maven-extension/src/test/java/org/citrusframework/yaks/maven/extension/ProjectModelEnricherTest.java
@@ -18,11 +18,13 @@
 package org.citrusframework.yaks.maven.extension;
 
 import java.io.File;
+import java.util.List;
 
 import org.apache.maven.execution.ProjectExecutionEvent;
 import org.apache.maven.lifecycle.LifecycleExecutionException;
 import org.apache.maven.model.Build;
 import org.apache.maven.model.Model;
+import org.apache.maven.model.Resource;
 import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.logging.console.ConsoleLogger;
 import org.junit.Assert;
@@ -70,22 +72,40 @@ public class ProjectModelEnricherTest {
 
             modelEnricher.beforeProjectExecution(executionEvent);
 
-            Assert.assertEquals(4L, projectModel.getBuild().getTestResources().size());
-            Assert.assertEquals("test-classes/org/citrusframework/yaks/feature", projectModel.getBuild().getTestResources().get(0).getTargetPath());
-            Assert.assertEquals(1L, projectModel.getBuild().getTestResources().get(0).getIncludes().size());
-            Assert.assertEquals("*.feature", projectModel.getBuild().getTestResources().get(0).getIncludes().get(0));
-            Assert.assertEquals("test-classes/org/citrusframework/yaks/groovy", projectModel.getBuild().getTestResources().get(1).getTargetPath());
-            Assert.assertEquals(1L, projectModel.getBuild().getTestResources().get(1).getIncludes().size());
-            Assert.assertEquals("*it.groovy", projectModel.getBuild().getTestResources().get(1).getIncludes().get(0));
-            Assert.assertEquals("test-classes/org/citrusframework/yaks/groovy", projectModel.getBuild().getTestResources().get(2).getTargetPath());
-            Assert.assertEquals(1L, projectModel.getBuild().getTestResources().get(2).getIncludes().size());
-            Assert.assertEquals("*test.groovy", projectModel.getBuild().getTestResources().get(2).getIncludes().get(0));
+            List<Resource> testResources = projectModel.getBuild().getTestResources();
+            Assert.assertEquals(6L, testResources.size());
 
-            Assert.assertEquals("test-classes", projectModel.getBuild().getTestResources().get(3).getTargetPath());
-            Assert.assertEquals(3L, projectModel.getBuild().getTestResources().get(3).getExcludes().size());
-            Assert.assertEquals("*.feature", projectModel.getBuild().getTestResources().get(3).getExcludes().get(0));
-            Assert.assertEquals("*it.groovy", projectModel.getBuild().getTestResources().get(3).getExcludes().get(1));
-            Assert.assertEquals("*test.groovy", projectModel.getBuild().getTestResources().get(3).getExcludes().get(2));
+            Resource gherkinResource = testResources.get(0);
+            Assert.assertEquals("test-classes/org/citrusframework/yaks/feature", gherkinResource.getTargetPath());
+            Assert.assertEquals(1L, gherkinResource.getIncludes().size());
+            Assert.assertEquals("*.feature", gherkinResource.getIncludes().get(0));
+
+            Resource groovyResource = testResources.get(1);
+            Assert.assertEquals("test-classes/org/citrusframework/yaks/groovy", groovyResource.getTargetPath());
+            Assert.assertEquals(1L, groovyResource.getIncludes().size());
+            Assert.assertEquals("*it.groovy", groovyResource.getIncludes().get(0));
+            groovyResource = testResources.get(2);
+            Assert.assertEquals("test-classes/org/citrusframework/yaks/groovy", groovyResource.getTargetPath());
+            Assert.assertEquals(1L, groovyResource.getIncludes().size());
+            Assert.assertEquals("*test.groovy", groovyResource.getIncludes().get(0));
+
+            Resource xmlResource = testResources.get(3);
+            Assert.assertEquals("test-classes/org/citrusframework/yaks/xml", xmlResource.getTargetPath());
+            Assert.assertEquals(1L, xmlResource.getIncludes().size());
+            Assert.assertEquals("*it.xml", xmlResource.getIncludes().get(0));
+            xmlResource = testResources.get(4);
+            Assert.assertEquals("test-classes/org/citrusframework/yaks/xml", xmlResource.getTargetPath());
+            Assert.assertEquals(1L, xmlResource.getIncludes().size());
+            Assert.assertEquals("*test.xml", xmlResource.getIncludes().get(0));
+
+            Resource otherResource = testResources.get(5);
+            Assert.assertEquals("test-classes", otherResource.getTargetPath());
+            Assert.assertEquals(5L, otherResource.getExcludes().size());
+            Assert.assertEquals("*.feature", otherResource.getExcludes().get(0));
+            Assert.assertEquals("*it.groovy", otherResource.getExcludes().get(1));
+            Assert.assertEquals("*test.groovy", otherResource.getExcludes().get(2));
+            Assert.assertEquals("*it.xml", otherResource.getExcludes().get(3));
+            Assert.assertEquals("*test.xml", otherResource.getExcludes().get(4));
         } finally {
             System.setProperty(ExtensionSettings.TESTS_PATH_KEY, "");
         }

--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -278,7 +278,7 @@ func (o *runCmdOptions) runTestGroup(cmd *cobra.Command, source string, results 
 
 func isKnownLanguage(fileName string) bool {
 	for _, language := range v1alpha1.KnownLanguages {
-		if strings.HasSuffix(fileName, fmt.Sprintf(".%s", string(language))) {
+		if language.SupportsFile(fileName) {
 			return true
 		}
 	}
@@ -605,7 +605,7 @@ func (o *runCmdOptions) configureTest(ctx context.Context, namespace string, fil
 			Source: v1alpha1.SourceSpec{
 				Name:     fileName,
 				Content:  data,
-				Language: language,
+				Language: language.GetName(),
 			},
 		},
 	}

--- a/pkg/cmd/util.go
+++ b/pkg/cmd/util.go
@@ -299,10 +299,10 @@ func getLanguage(fileName string) v1alpha1.Language {
 	extension := path.Ext(fileName)
 
 	for _, language := range v1alpha1.KnownLanguages {
-		if extension == fmt.Sprintf(".%s", string(language)) {
+		if extension == fmt.Sprintf(".%s", language.GetName()) {
 			return language
 		}
 	}
 
-	return v1alpha1.LanguageGherkin
+	return &v1alpha1.Gherkin
 }

--- a/pkg/controller/test/start.go
+++ b/pkg/controller/test/start.go
@@ -267,7 +267,7 @@ func getMavenArgLine(test *v1alpha1.Test) []string {
 	argLine = append(argLine, "verify")
 
 	// choose test to run based on given language
-	argLine = append(argLine, fmt.Sprintf("-Dit.test=org.citrusframework.yaks.%s.Yaks_IT", string(test.Spec.Source.Language)))
+	argLine = append(argLine, fmt.Sprintf("-Dit.test=org.citrusframework.yaks.%s.Yaks_IT", test.Spec.Source.Language))
 
 	// add system property settings
 	argLine = append(argLine, "-Dmaven.repo.local=/deployments/artifacts/m2")
@@ -704,7 +704,7 @@ func (action *startAction) addLogger(test *v1alpha1.Test, job *batchv1.Job) {
 			Name:  envvar.LoggersEnv,
 			Value: strings.Join(test.Spec.Runtime.Logger, ","),
 		})
-	} else if test.Spec.Source.Language != v1alpha1.LanguageGherkin {
+	} else if test.Spec.Source.Language != v1alpha1.Gherkin.GetName() {
 		job.Spec.Template.Spec.Containers[0].Env = append(job.Spec.Template.Spec.Containers[0].Env, v1.EnvVar{
 			Name:  envvar.LoggersEnv,
 			Value: "com.consol.citrus=INFO,org.citrusframework.yaks=INFO",


### PR DESCRIPTION
- Enable Xml tests in YAKS runtime
- Support *it.groovy and *test.groovy files as test sources
- Support *it.xml and *test.xml files as test sources

Fixes #438 