### PR TITLE
chore: Label KubeDock containers explicitly

### DIFF
--- a/examples/selenium/yaks-config.yaml
+++ b/examples/selenium/yaks-config.yaml
@@ -18,6 +18,7 @@
 config:
   runtime:
     selenium:
+      enabled: true
       image: selenium/standalone-chrome:106.0
     env:
       - name: YAKS_SELENIUM_BROWSER_TYPE

--- a/java/steps/yaks-kubernetes/src/main/java/org/citrusframework/yaks/kubernetes/KubernetesSteps.java
+++ b/java/steps/yaks-kubernetes/src/main/java/org/citrusframework/yaks/kubernetes/KubernetesSteps.java
@@ -530,7 +530,7 @@ public class KubernetesSteps {
                 .timeout(watchLogsTimeout));
     }
 
-    @Then("^create annotation ([^\\s]+)=([^\\s]+) on Kubernetes (pod|secret|service) ([a-z\\.0-9-]+)$")
+    @Then("^create annotation ([^\\s]+)=([^\\s]+) on Kubernetes (pod|secret|service|deployment) ([a-z\\.0-9-]+)$")
     public void createAnnotationOnResource(String annotation, String value, String resourceType, String resourceName) {
         runner.run(kubernetes().client(k8sClient)
                         .resources()
@@ -538,7 +538,7 @@ public class KubernetesSteps {
                         .annotation(annotation, value));
     }
 
-    @Then("^create annotations on Kubernetes (pod|secret|service) ([a-z\\.0-9-]+)$")
+    @Then("^create annotations on Kubernetes (pod|secret|service|deployment) ([a-z\\.0-9-]+)$")
     public void createAnnotationOnResource(String resourceType, String resourceName, DataTable table) {
         Map<String, String> annotations = table.asMap(String.class, String.class);
         runner.run(kubernetes().client(k8sClient)
@@ -547,7 +547,7 @@ public class KubernetesSteps {
                 .annotations(annotations));
     }
 
-    @Then("^create label ([^\\s]+)=([^\\s]+) on Kubernetes (pod|secret|service) ([a-z\\.0-9-]+)$")
+    @Then("^create label ([^\\s]+)=([^\\s]+) on Kubernetes (pod|secret|service|deployment) ([a-z\\.0-9-]+)$")
     public void createLabelOnResource(String label, String value, String resourceType, String resourceName) {
         runner.run(kubernetes().client(k8sClient)
                         .resources()
@@ -555,9 +555,12 @@ public class KubernetesSteps {
                         .label(label, value));
     }
 
-    @Then("^create labels on Kubernetes (pod|secret|service) ([a-z\\.0-9-]+)$")
+    @Then("^create labels on Kubernetes (pod|secret|service|deployment) ([a-z\\.0-9-]+)$")
     public void createLabelOnResource(String resourceType, String resourceName, DataTable table) {
-        Map<String, String> labels = table.asMap(String.class, String.class);
+        createLabelsOnResource(resourceType, resourceName, table.asMap(String.class, String.class));
+    }
+
+    public void createLabelsOnResource(String resourceType, String resourceName, Map<String, String> labels) {
         runner.run(kubernetes().client(k8sClient)
                 .resources()
                 .addLabel(resourceName, resourceType.toUpperCase(Locale.US))

--- a/java/steps/yaks-kubernetes/src/main/java/org/citrusframework/yaks/kubernetes/actions/CreateAnnotationsAction.java
+++ b/java/steps/yaks-kubernetes/src/main/java/org/citrusframework/yaks/kubernetes/actions/CreateAnnotationsAction.java
@@ -25,6 +25,7 @@ import com.consol.citrus.exceptions.CitrusRuntimeException;
 import io.fabric8.kubernetes.api.model.PodBuilder;
 import io.fabric8.kubernetes.api.model.SecretBuilder;
 import io.fabric8.kubernetes.api.model.ServiceBuilder;
+import io.fabric8.kubernetes.api.model.apps.DeploymentBuilder;
 
 /**
  * @author Christoph Deppisch
@@ -47,6 +48,7 @@ public class CreateAnnotationsAction extends AbstractKubernetesAction implements
      * Enumeration of supported Kubernetes resources this action is capable of adding annotations to.
      */
     public enum ResourceType {
+        DEPLOYMENT,
         POD,
         SECRET,
         SERVICE
@@ -57,6 +59,16 @@ public class CreateAnnotationsAction extends AbstractKubernetesAction implements
         Map<String, String> resolvedAnnotations = context.resolveDynamicValuesInMap(annotations);
 
         switch (resourceType) {
+            case DEPLOYMENT:
+                getKubernetesClient().apps().deployments()
+                        .inNamespace(namespace(context))
+                        .withName(resourceName)
+                        .edit(d -> new DeploymentBuilder(d)
+                                .editMetadata()
+                                .addToAnnotations(resolvedAnnotations)
+                                .endMetadata()
+                                .build());
+                break;
             case POD:
                 getKubernetesClient().pods()
                         .inNamespace(namespace(context))
@@ -104,6 +116,11 @@ public class CreateAnnotationsAction extends AbstractKubernetesAction implements
         public Builder name(String resourceName) {
             this.resourceName = resourceName;
             return this;
+        }
+
+        public Builder deployment(String name) {
+            this.resourceName = name;
+            return type(ResourceType.DEPLOYMENT);
         }
 
         public Builder pod(String name) {

--- a/java/steps/yaks-kubernetes/src/main/java/org/citrusframework/yaks/kubernetes/actions/KubernetesActionBuilder.java
+++ b/java/steps/yaks-kubernetes/src/main/java/org/citrusframework/yaks/kubernetes/actions/KubernetesActionBuilder.java
@@ -76,6 +76,14 @@ public class KubernetesActionBuilder implements TestActionBuilder.DelegatingTest
      * Performs actions on Kubernetes pods.
      * @return
      */
+    public KubernetesActionBuilder.DeploymentActionBuilder deployments() {
+        return new DeploymentActionBuilder();
+    }
+
+    /**
+     * Performs actions on Kubernetes pods.
+     * @return
+     */
     public KubernetesActionBuilder.PodActionBuilder pods() {
         return new PodActionBuilder();
     }
@@ -207,6 +215,33 @@ public class KubernetesActionBuilder implements TestActionBuilder.DelegatingTest
             delegate = builder;
             return builder;
         }
+    }
+
+    public class DeploymentActionBuilder {
+        /**
+         * Add annotation on deployment instance.
+         * @param deploymentName the name of the Kubernetes deployment.
+         */
+        public CreateAnnotationsAction.Builder addAnnotation(String deploymentName) {
+            CreateAnnotationsAction.Builder builder = new CreateAnnotationsAction.Builder()
+                    .client(kubernetesClient)
+                    .deployment(deploymentName);
+            delegate = builder;
+            return builder;
+        }
+
+        /**
+         * Add label on deployment instance.
+         * @param deploymentName the name of the Kubernetes deployment.
+         */
+        public CreateLabelsAction.Builder addLabel(String deploymentName) {
+            CreateLabelsAction.Builder builder = new CreateLabelsAction.Builder()
+                    .client(kubernetesClient)
+                    .deployment(deploymentName);
+            delegate = builder;
+            return builder;
+        }
+
     }
 
     public class PodActionBuilder {

--- a/java/steps/yaks-testcontainers/pom.xml
+++ b/java/steps/yaks-testcontainers/pom.xml
@@ -30,6 +30,12 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.citrusframework.yaks</groupId>
+      <artifactId>yaks-kubernetes</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
       <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>
     </dependency>
@@ -144,6 +150,16 @@
     <dependency>
       <groupId>com.consol.citrus</groupId>
       <artifactId>citrus-validation-text</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.fabric8</groupId>
+      <artifactId>kubernetes-server-mock</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.squareup.okhttp3</groupId>
+      <artifactId>mockwebserver</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/java/steps/yaks-testcontainers/src/test/java/org/citrusframework/yaks/testcontainers/KubernetesServiceConfiguration.java
+++ b/java/steps/yaks-testcontainers/src/test/java/org/citrusframework/yaks/testcontainers/KubernetesServiceConfiguration.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.yaks.testcontainers;
+
+import java.util.HashMap;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesCrudDispatcher;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
+import io.fabric8.mockwebserver.Context;
+import okhttp3.mockwebserver.MockWebServer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.DependsOn;
+
+/**
+ * @author Christoph Deppisch
+ */
+@Configuration
+public class KubernetesServiceConfiguration {
+
+    private final KubernetesMockServer k8sServer = new KubernetesMockServer(new Context(), new MockWebServer(),
+            new HashMap<>(), new KubernetesCrudDispatcher(), false);
+
+    @Bean(initMethod = "init", destroyMethod = "destroy")
+    public KubernetesMockServer k8sMockServer() {
+        return k8sServer;
+    }
+
+    @Bean(destroyMethod = "close")
+    @DependsOn("k8sMockServer")
+    public KubernetesClient kubernetesClient() {
+        return k8sServer.createClient();
+    }
+}

--- a/java/steps/yaks-testcontainers/src/test/resources/citrus-application.properties
+++ b/java/steps/yaks-testcontainers/src/test/resources/citrus-application.properties
@@ -16,3 +16,4 @@
 #
 
 citrus.default.message.type=PLAINTEXT
+citrus.spring.java.config=org.citrusframework.yaks.testcontainers.KubernetesServiceConfiguration

--- a/pkg/cmd/config/config.go
+++ b/pkg/cmd/config/config.go
@@ -70,13 +70,15 @@ type CucumberConfig struct {
 }
 
 type SeleniumConfig struct {
+	Enabled   bool   `yaml:"enabled"`
 	Image     string `yaml:"image"`
 	RunAsUser int    `yaml:"runAsUser"`
 }
 
 type TestContainersConfig struct {
-	Enabled   bool `yaml:"enabled"`
-	RunAsUser int  `yaml:"runAsUser"`
+	Enabled   bool   `yaml:"enabled"`
+	Image     string `yaml:"image"`
+	RunAsUser int    `yaml:"runAsUser"`
 }
 
 type EnvConfig struct {

--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -56,6 +56,7 @@ const (
 	ConfigFile    = "yaks-config.yaml"
 	SettingsFile  = "yaks.settings.yaml"
 	KubeDockImage = "joyrex2001/kubedock:0.9.0"
+	SeleniumImage = "selenium/standalone-chrome:106.0"
 )
 
 const (
@@ -661,16 +662,28 @@ func (o *runCmdOptions) configureTest(ctx context.Context, namespace string, fil
 		test.Spec.Secret = runConfig.Config.Runtime.Secret
 	}
 
-	if runConfig.Config.Runtime.Selenium.Image != "" {
+	if runConfig.Config.Runtime.Selenium.Enabled {
+		image := SeleniumImage
+
+		if runConfig.Config.Runtime.Selenium.Image != "" {
+			image = runConfig.Config.Runtime.Selenium.Image
+		}
+
 		test.Spec.Selenium = v1alpha1.SeleniumSpec{
-			Image:     runConfig.Config.Runtime.Selenium.Image,
+			Image:     image,
 			RunAsUser: runConfig.Config.Runtime.Selenium.RunAsUser,
 		}
 	}
 
 	if runConfig.Config.Runtime.TestContainers.Enabled {
+		image := KubeDockImage
+
+		if runConfig.Config.Runtime.TestContainers.Image != "" {
+			image = runConfig.Config.Runtime.TestContainers.Image
+		}
+
 		test.Spec.KubeDock = v1alpha1.KubeDockSpec{
-			Image:     KubeDockImage,
+			Image:     image,
 			RunAsUser: runConfig.Config.Runtime.TestContainers.RunAsUser,
 		}
 	}


### PR DESCRIPTION
- Use Kubernetes client to label kubedock deployment resource after its creation
- Align kubedock and selenium extension configuration