### PR TITLE
fix(#456): Switch operator base image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,10 +39,11 @@ jobs:
   build:
     runs-on: ubuntu-20.04
     steps:
-    - name: Set up JDK 11
-      uses: AdoptOpenJDK/install-jdk@v1
+    - name: Set up JDK
+      uses: actions/setup-java@v3
       with:
-        version: "11"
+        java-version: '11'
+        distribution: 'temurin'
     - name: Install Go
       uses: actions/setup-go@v1
       with:
@@ -74,10 +75,11 @@ jobs:
       YAKS_IMAGE_VERSION: "latest"
       YAKS_RUN_OPTIONS: "--timeout=180s"
     steps:
-    - name: Set up JDK 11
-      uses: AdoptOpenJDK/install-jdk@v1
+    - name: Set up JDK
+      uses: actions/setup-java@v3
       with:
-        version: "11"
+        java-version: '11'
+        distribution: 'temurin'
     - name: Install Go
       uses: actions/setup-go@v1
       with:
@@ -122,7 +124,7 @@ jobs:
         export KAMEL_INSTALL_REGISTRY=$KIND_REGISTRY
         export KAMEL_INSTALL_REGISTRY_INSECURE=true
         
-        kamel install --global --olm=false
+        kamel install --global --olm=false --operator-env-vars KAMEL_BASE_IMAGE=docker.io/eclipse-temurin:11
     - name: Install YAKS
       run: |
         yaks install --operator-image $YAKS_IMAGE_NAME:$YAKS_IMAGE_VERSION

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -28,10 +28,11 @@ jobs:
     if: github.ref == 'refs/heads/main' && github.repository == 'citrusframework/yaks'
 
     steps:
-    - name: Set up JDK 11
-      uses: AdoptOpenJDK/install-jdk@v1
+    - name: Set up JDK
+      uses: actions/setup-java@v3
       with:
-        version: "11"
+        java-version: '11'
+        distribution: 'temurin'
     - name: Install Go
       uses: actions/setup-go@v1
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,10 +31,11 @@ jobs:
     if: github.ref == 'refs/heads/main' && github.repository == 'citrusframework/yaks'
 
     steps:
-    - name: Set up JDK 11
-      uses: AdoptOpenJDK/install-jdk@v1
+    - name: Set up JDK
+      uses: actions/setup-java@v3
       with:
-        version: "11"
+        java-version: '11'
+        distribution: 'temurin'
     - name: Install Go
       uses: actions/setup-go@v1
       with:

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -29,10 +29,11 @@ jobs:
     if: github.repository == 'citrusframework/yaks'
 
     steps:
-    - name: Set up JDK 11
-      uses: AdoptOpenJDK/install-jdk@v1
+    - name: Set up JDK
+      uses: actions/setup-java@v3
       with:
-        version: "11"
+        java-version: '11'
+        distribution: 'temurin'
     - name: Install Go
       uses: actions/setup-go@v1
       with:

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM adoptopenjdk/openjdk11:slim
+FROM eclipse-temurin:11
 
 ARG MAVEN_VERSION="3.8.6"
 ARG MAVEN_HOME="/usr/share/maven"


### PR DESCRIPTION
- Use eclipse-temurin:11 base image as adoptopenjdk/openjdk11:slim has been deprecated and is no longer released for linux/amd64
- Use eclipse temurin as Java distribution for github actions

Fixes #456 