### PR TITLE
fix(#475): Add function to resolve K8s service cluster ip

### DIFF
--- a/java/steps/yaks-kubernetes/src/main/java/org/citrusframework/yaks/kubernetes/KubernetesSupport.java
+++ b/java/steps/yaks-kubernetes/src/main/java/org/citrusframework/yaks/kubernetes/KubernetesSupport.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import com.consol.citrus.Citrus;
+import com.consol.citrus.context.TestContext;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationFeature;
@@ -69,12 +70,46 @@ public final class KubernetesSupport {
         // prevent instantiation of utility class
     }
 
+    /**
+     * Retrieve current Kubernetes client if set in Citrus context as bean reference.
+     * Otherwise, create new default instance.
+     * @param citrus holding the potential bean reference to the client instance.
+     * @return
+     */
     public static KubernetesClient getKubernetesClient(Citrus citrus) {
         if (citrus.getCitrusContext().getReferenceResolver().resolveAll(KubernetesClient.class).size() == 1L) {
             return citrus.getCitrusContext().getReferenceResolver().resolve(KubernetesClient.class);
         } else {
             return new KubernetesClientBuilder().build();
         }
+    }
+
+    /**
+     * Retrieve current Kubernetes client if set in test context as bean reference.
+     * Otherwise, create new default instance.
+     * @param context holding the potential client bean reference.
+     * @return
+     */
+    public static KubernetesClient getKubernetesClient(TestContext context) {
+        if (context.getReferenceResolver().resolveAll(KubernetesClient.class).size() == 1L) {
+            return context.getReferenceResolver().resolve(KubernetesClient.class);
+        } else {
+            return new KubernetesClientBuilder().build();
+        }
+    }
+
+    /**
+     * Retrieve current namespace set as test variable.
+     * In case no suitable test variable is available use namespace loaded from Kubernetes settings via environment settings.
+     * @param context potentially holding the namespace variable.
+     * @return
+     */
+    public static String getNamespace(TestContext context) {
+        if (context.getVariables().containsKey(KubernetesVariableNames.NAMESPACE.value())) {
+            return context.getVariable(KubernetesVariableNames.NAMESPACE.value());
+        }
+
+        return KubernetesSettings.getNamespace();
     }
 
     public static Yaml yaml() {
@@ -185,4 +220,5 @@ public final class KubernetesSupport {
 
         return Optional.empty();
     }
+
 }

--- a/java/steps/yaks-kubernetes/src/main/java/org/citrusframework/yaks/kubernetes/actions/KubernetesAction.java
+++ b/java/steps/yaks-kubernetes/src/main/java/org/citrusframework/yaks/kubernetes/actions/KubernetesAction.java
@@ -20,8 +20,7 @@ package org.citrusframework.yaks.kubernetes.actions;
 import com.consol.citrus.TestAction;
 import com.consol.citrus.context.TestContext;
 import io.fabric8.kubernetes.client.KubernetesClient;
-import org.citrusframework.yaks.kubernetes.KubernetesSettings;
-import org.citrusframework.yaks.kubernetes.KubernetesVariableNames;
+import org.citrusframework.yaks.kubernetes.KubernetesSupport;
 
 /**
  * Base action provides access to Kubernetes properties such as broker name. These properties are read from
@@ -46,11 +45,7 @@ public interface KubernetesAction extends TestAction {
      * @return
      */
     default String namespace(TestContext context) {
-        if (context.getVariables().containsKey(KubernetesVariableNames.NAMESPACE.value())) {
-            return context.getVariable(KubernetesVariableNames.NAMESPACE.value());
-        }
-
-        return KubernetesSettings.getNamespace();
+        return KubernetesSupport.getNamespace(context);
     }
 }
 

--- a/java/steps/yaks-kubernetes/src/main/java/org/citrusframework/yaks/kubernetes/functions/ServiceClusterIpFunction.java
+++ b/java/steps/yaks-kubernetes/src/main/java/org/citrusframework/yaks/kubernetes/functions/ServiceClusterIpFunction.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.yaks.kubernetes.functions;
+
+import java.util.List;
+
+import com.consol.citrus.context.TestContext;
+import com.consol.citrus.exceptions.CitrusRuntimeException;
+import com.consol.citrus.exceptions.InvalidFunctionUsageException;
+import com.consol.citrus.functions.Function;
+import io.fabric8.kubernetes.api.model.Service;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import org.citrusframework.yaks.YaksSettings;
+import org.citrusframework.yaks.kubernetes.KubernetesSupport;
+
+public class ServiceClusterIpFunction implements Function {
+
+    @Override
+    public String execute(List<String> parameterList, TestContext context) {
+        if (YaksSettings.isLocal()) {
+            return "127.0.0.1";
+        }
+
+        if (parameterList.isEmpty()) {
+            throw new InvalidFunctionUsageException("Function parameters must not be empty - please provide a proper service name");
+        }
+
+        String serviceName = parameterList.get(0);
+
+        String namespace;
+        if (parameterList.size() > 1) {
+            namespace = parameterList.get(1);
+        } else {
+            namespace = KubernetesSupport.getNamespace(context);
+        }
+
+        KubernetesClient k8sClient = KubernetesSupport.getKubernetesClient(context);
+
+        Service service = k8sClient.services()
+                    .inNamespace(namespace)
+                    .withName(serviceName)
+                    .get();
+
+        if (service == null) {
+            throw new CitrusRuntimeException(String.format("Unable to resolve service instance %s/%s", namespace, serviceName));
+        }
+
+        String clusterIp = service.getSpec().getClusterIP();
+        if (clusterIp != null) {
+            return clusterIp;
+        }
+
+        if (!service.getSpec().getExternalIPs().isEmpty()) {
+            return service.getSpec().getExternalIPs().get(0);
+        }
+
+        throw new CitrusRuntimeException(String.format("Unable to resolve cluster ip on service instance %s - no cluster ip set", service.getMetadata().getName()));
+    }
+}

--- a/java/steps/yaks-kubernetes/src/main/resources/META-INF/citrus/function/serviceClusterIp
+++ b/java/steps/yaks-kubernetes/src/main/resources/META-INF/citrus/function/serviceClusterIp
@@ -1,0 +1,1 @@
+type=org.citrusframework.yaks.kubernetes.functions.ServiceClusterIpFunction

--- a/java/steps/yaks-kubernetes/src/test/java/org/citrusframework/yaks/kubernetes/functions/ServiceClusterIpFunctionTest.java
+++ b/java/steps/yaks-kubernetes/src/test/java/org/citrusframework/yaks/kubernetes/functions/ServiceClusterIpFunctionTest.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citrusframework.yaks.kubernetes.functions;
+
+import java.util.List;
+
+import com.consol.citrus.Citrus;
+import com.consol.citrus.context.TestContext;
+import com.consol.citrus.exceptions.CitrusRuntimeException;
+import com.consol.citrus.functions.DefaultFunctionLibrary;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.Service;
+import io.fabric8.kubernetes.api.model.ServiceSpec;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import org.citrusframework.yaks.kubernetes.KubernetesSupport;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ServiceClusterIpFunctionTest {
+
+    private final Citrus citrus = Citrus.newInstance();
+    private final TestContext context = citrus.getCitrusContext().createTestContext();
+    private final KubernetesClient k8sClient = KubernetesSupport.getKubernetesClient(context);
+
+    @Test
+    public void shouldResolveServiceClusterIp() {
+        Service service = new Service();
+        service.setMetadata(new ObjectMeta());
+        service.getMetadata().setNamespace(KubernetesSupport.getNamespace(context));
+        service.getMetadata().setName("myService");
+        service.setSpec(new ServiceSpec());
+        service.getSpec().setClusterIP("127.0.0.1");
+
+        k8sClient.services().inNamespace(KubernetesSupport.getNamespace(context))
+                .resource(service)
+                .create();
+
+        Assert.assertEquals("127.0.0.1", new ServiceClusterIpFunction().execute(List.of("myService"), context));
+    }
+
+    @Test
+    public void shouldFallbackToExternalIPs() {
+        Service service = new Service();
+        service.setMetadata(new ObjectMeta());
+        service.getMetadata().setNamespace(KubernetesSupport.getNamespace(context));
+        service.getMetadata().setName("myExternalService");
+        service.setSpec(new ServiceSpec());
+        service.getSpec().setExternalIPs(List.of("127.0.0.1"));
+
+        k8sClient.services().inNamespace(KubernetesSupport.getNamespace(context))
+                .resource(service)
+                .create();
+
+        Assert.assertEquals("127.0.0.1", new ServiceClusterIpFunction().execute(List.of("myExternalService"), context));
+    }
+
+    @Test
+    public void shouldFailOnUnknownService() {
+        Assert.assertThrows(CitrusRuntimeException.class,
+                () -> new ServiceClusterIpFunction().execute(List.of("unknown"), context));
+    }
+
+    @Test
+    public void shouldFailOnNoServiceClusterIpAvailable() {
+        Service service = new Service();
+        service.setMetadata(new ObjectMeta());
+        service.getMetadata().setNamespace(KubernetesSupport.getNamespace(context));
+        service.getMetadata().setName("noClusterIpService");
+        service.setSpec(new ServiceSpec());
+
+        k8sClient.services().inNamespace(KubernetesSupport.getNamespace(context))
+                .resource(service)
+                .create();
+
+        Assert.assertThrows(CitrusRuntimeException.class,
+                () -> new ServiceClusterIpFunction().execute(List.of("noClusterIpService"), context));
+    }
+
+    @Test
+    public void shouldResolve() {
+        Assert.assertNotNull(new DefaultFunctionLibrary().getFunction("serviceClusterIp"));
+    }
+}


### PR DESCRIPTION
Function retrieves a service cluster ip from given service name and optional namespace